### PR TITLE
feat: Apply responsive 'middle 3rd' layout to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
             </button>
           </div>
         </div>
+        <div class="w-1/3 mx-auto lg:w-full lg:mx-0"> <!-- NEW WRAPPER DIV -->
         <div class="flex p-4 @container">
           <div class="flex w-full flex-col gap-4 items-center">
             <div class="flex gap-4 flex-col items-center">
@@ -100,6 +101,7 @@
             </div>
           </div>
         </div>
+        </div> <!-- END NEW WRAPPER DIV -->
       </div>
       <div>
         <div class="flex gap-2 border-t border-[#f2f2f2] bg-white px-4 pb-3 pt-2">


### PR DESCRIPTION
Implements a responsive layout for the main content of index.html. The content will now be displayed in the middle third of the screen for viewports narrower than 1024px (Tailwind's 'lg' breakpoint). For viewports 1024px and wider, the content will revert to a full-width layout.

This change mirrors the 'middle 3rd' concept from nCode/index-nCode.html but is conditionally applied based on screen width as per the issue requirements. A new wrapper div with classes 'w-1/3 mx-auto lg:w-full lg:mx-0' was added around the main content sections (profile, about, contact, projects) to achieve this effect.