### PR TITLE
Fix: Prevent contact buttons from overflowing screen.

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       class="relative flex size-full min-h-screen flex-col bg-white justify-between group/design-root overflow-x-hidden"
       style='font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;'
     >
-      <div>
+      <div class="px-4">
         <div class="flex items-center bg-white p-4 pb-2 justify-between">
 
           <div class="flex w-12 items-center justify-end">
@@ -45,7 +45,7 @@
           I’m a jack of all trades, based in the beautiful Whidbey Island area, and specializing in functional security and machine learning web design. Let's get creative!
         </p>
         <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Contact</h2>
-    <button onclick="window.location.href = 'mailto:thestephenmiller@me.com';" class="flex items-center justify-center gap-4 bg-gray-200 hover:bg-gray-300 text-black font-medium py-3 px-4 rounded-lg w-full min-h-14 text-base mx-4">
+    <button onclick="window.location.href = 'mailto:thestephenmiller@me.com';" class="flex items-center justify-center gap-4 bg-gray-200 hover:bg-gray-300 text-black font-medium py-3 px-4 rounded-lg w-full min-h-14 text-base">
           <div class="text-[#141414] flex items-center justify-center rounded-lg bg-[#f2f2f2] shrink-0 size-10" data-icon="Envelope" data-size="24px" data-weight="regular">
             <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
               <path
@@ -55,7 +55,7 @@
           </div>
           <p class="text-[#141414] text-base font-normal leading-normal truncate">thestephenmiller@me.com</p>
     </button>
-    <button onclick="window.open('https://linkedIn.com/in/thestephenmiller', '_blank');" class="flex items-center justify-center gap-4 bg-gray-200 hover:bg-gray-300 text-black font-medium py-3 px-4 rounded-lg w-full min-h-14 text-base mx-4 mt-2">
+    <button onclick="window.open('https://linkedIn.com/in/thestephenmiller', '_blank');" class="flex items-center justify-center gap-4 bg-gray-200 hover:bg-gray-300 text-black font-medium py-3 px-4 rounded-lg w-full min-h-14 text-base mt-2">
       <div class="text-[#141414] flex items-center justify-center rounded-lg bg-[#f2f2f2] shrink-0 size-10" data-icon="LinkedIn" data-size="24px" data-weight="regular">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>


### PR DESCRIPTION
Removed horizontal margins (mx-4) from the email and LinkedIn buttons. Added horizontal padding (px-4) to the parent container of the buttons.

This ensures the buttons expand to the full width of their padded container, preventing them from extending off the edge of the screen, especially on mobile views.