### PR TITLE
feat: Implement demo file explorer for GoldHash

### DIFF
--- a/Projects/GoldHash/demo_files/Jokes Folder 1/joke1.txt
+++ b/Projects/GoldHash/demo_files/Jokes Folder 1/joke1.txt
@@ -1,0 +1,1 @@
+Why don't scientists trust atoms? Because they make up everything!

--- a/Projects/GoldHash/demo_files/Jokes Folder 2/joke2.txt
+++ b/Projects/GoldHash/demo_files/Jokes Folder 2/joke2.txt
@@ -1,0 +1,1 @@
+Why did the scarecrow win an award? Because he was outstanding in his field!

--- a/Projects/GoldHash/demo_files/Jokes Folder 3/joke3.txt
+++ b/Projects/GoldHash/demo_files/Jokes Folder 3/joke3.txt
@@ -1,0 +1,1 @@
+Why don't skeletons fight each other? They don't have the guts.

--- a/Projects/GoldHash/index.html
+++ b/Projects/GoldHash/index.html
@@ -36,27 +36,7 @@
 <span class="material-icons-outlined" style="font-size: 20px"> create_new_folder </span>
 <span class="truncate">Add Folder</span>
 </button>
-<nav class="flex-grow space-y-1 overflow-y-auto">
-<a class="flex items-center gap-3 rounded-lg bg-[#1A2B3A] px-3 py-2.5 text-sm font-medium transition-colors hover:bg-[#223649]" href="#">
-<span class="material-icons-outlined text-slate-400" style="font-size: 20px"> folder </span>
-              /Users/johndoe/Documents
-            </a>
-<a class="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]" href="#">
-<span class="material-icons-outlined text-slate-400" style="font-size: 20px"> folder </span>
-              /Users/johndoe/Downloads
-            </a>
-<a class="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]" href="#">
-<span class="material-icons-outlined text-slate-400" style="font-size: 20px"> folder </span>
-              /Users/johndoe/Pictures
-            </a>
-<a class="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]" href="#">
-<span class="material-icons-outlined text-slate-400" style="font-size: 20px"> folder </span>
-              /Users/johndoe/Desktop
-            </a>
-<a class="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]" href="#">
-<span class="material-icons-outlined text-slate-400" style="font-size: 20px"> folder </span>
-              /Users/johndoe/Applications
-            </a>
+<nav class="flex-grow space-y-1 overflow-y-auto" id="sidebar-nav">
 </nav>
 <div class="mt-auto space-y-2 border-t border-t-[#1A2B3A] pt-4">
 <button class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]">
@@ -99,34 +79,7 @@
 <th class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-360 px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-slate-400">Size</th>
 </tr>
 </thead>
-<tbody class="divide-y divide-[#1A2B3A]">
-<tr>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-120 whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-100">Report.pdf</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-240 whitespace-nowrap px-6 py-4 text-sm text-slate-300">2024-01-15 09:00 AM</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-360 whitespace-nowrap px-6 py-4 text-sm text-slate-300">2.5 MB</td>
-</tr>
-<tr>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-120 whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-100">Presentation.pptx</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-240 whitespace-nowrap px-6 py-4 text-sm text-slate-300">2024-01-10 02:00 PM</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-360 whitespace-nowrap px-6 py-4 text-sm text-slate-300">5.0 MB</td>
-</tr>
-<tr>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-120 whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-100">Spreadsheet.xlsx</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-240 whitespace-nowrap px-6 py-4 text-sm text-slate-300">2024-01-05 11:00 AM</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-360 whitespace-nowrap px-6 py-4 text-sm text-slate-300">1.2 MB</td>
-</tr>
-<tr>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-120 whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-100">
-                        Project Proposal.docx
-                      </td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-240 whitespace-nowrap px-6 py-4 text-sm text-slate-300">2023-12-20 04:00 PM</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-360 whitespace-nowrap px-6 py-4 text-sm text-slate-300">3.8 MB</td>
-</tr>
-<tr>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-120 whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-100">Meeting Notes.txt</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-240 whitespace-nowrap px-6 py-4 text-sm text-slate-300">2023-12-15 10:00 AM</td>
-<td class="table-9e93adbd-9b96-4203-8d28-0f3ea4a91f97-column-360 whitespace-nowrap px-6 py-4 text-sm text-slate-300">0.5 MB</td>
-</tr>
+<tbody class="divide-y divide-[#1A2B3A]" id="documents-tbody">
 </tbody>
 </table>
 </div>

--- a/Projects/GoldHash/script.js
+++ b/Projects/GoldHash/script.js
@@ -1,36 +1,147 @@
-// script.js
+document.addEventListener('DOMContentLoaded', () => {
+    const sidebarNav = document.getElementById('sidebar-nav');
+    const documentsTbody = document.getElementById('documents-tbody');
+    const mainContent = document.querySelector('main.ml-80'); // Used to display file content
 
-// Functionality for adding folders to monitor
-// This section will contain code for:
-// - Handling user input for folder paths.
-// - Storing the list of monitored folders (e.g., in localStorage or sending to a backend).
-// - Updating the UI to display the list of monitored folders.
-// - Potentially validating folder paths.
+    const demoFiles = {
+        "Jokes Folder 1": {
+            "joke1.txt": "Why don't scientists trust atoms? Because they make up everything!"
+        },
+        "Jokes Folder 2": {
+            "joke2.txt": "Why did the scarecrow win an award? Because he was outstanding in his field!"
+        },
+        "Jokes Folder 3": {
+            "joke3.txt": "Why don't skeletons fight each other? They don't have the guts."
+        }
+    };
 
-// Functionality for scanning files within monitored folders
-// This section will contain code for:
-// - Iterating through files in the selected/monitored folders.
-// - Calculating file hashes (e.g., SHA-256) for integrity checking.
-// - Storing baseline hashes for comparison.
-// - Comparing current file hashes against baseline hashes to detect changes.
-// - Logging detected changes (new files, modified files, deleted files).
+    function displayFileContent(folderName, fileName) {
+        const content = demoFiles[folderName]?.[fileName];
+        if (content && mainContent) {
+            // Clear existing content in main area (documents table, stats, etc.)
+            // For simplicity, we'll just hide the existing sections and show the file content.
+            // A more robust solution might involve a dedicated content display area.
+            const sectionsToHide = mainContent.querySelectorAll('section');
+            sectionsToHide.forEach(section => section.style.display = 'none');
 
-// Functionality for displaying statistics and file changes
-// This section will contain code for:
-// - Updating the UI with statistics (e.g., total files monitored, files changed, log size).
-// - Displaying a list or table of detected file changes.
-// - Implementing filters or sorting for the displayed changes.
-// - Visualizing file changes over time (e.g., using a chart library).
+            let fileContentDiv = document.getElementById('file-content-display');
+            if (!fileContentDiv) {
+                fileContentDiv = document.createElement('div');
+                fileContentDiv.id = 'file-content-display';
+                fileContentDiv.className = 'p-8 text-slate-100'; // Basic styling
+                mainContent.appendChild(fileContentDiv);
+            }
+            fileContentDiv.style.display = 'block'; // Show file content display
 
-// Event listeners for UI elements
-// e.g., document.getElementById('addFolderButton').addEventListener('click', handleAddFolder);
-// e.g., document.getElementById('scanButton').addEventListener('click', handleScanFiles);
+            // Sanitize content before inserting as HTML
+            const pre = document.createElement('pre');
+            pre.textContent = content;
 
-// Initialization function (if needed)
-// function init() {
-//   // Load monitored folders
-//   // Display initial statistics
-// }
+            const backButton = document.createElement('button');
+            backButton.textContent = 'Back to Files';
+            backButton.className = 'mb-4 px-4 py-2 bg-[#0c7ff2] text-white rounded hover:bg-blue-600 transition-colors';
+            backButton.onclick = () => {
+                sectionsToHide.forEach(section => section.style.display = 'block'); // Or 'flex' or 'grid' depending on original
+                fileContentDiv.style.display = 'none';
+                // Redisplay the folder contents
+                displayFolderContents(folderName);
+            };
 
-// Call init() when the DOM is ready
-// document.addEventListener('DOMContentLoaded', init);
+            fileContentDiv.innerHTML = ''; // Clear previous content
+            fileContentDiv.appendChild(backButton);
+            fileContentDiv.appendChild(pre);
+
+        } else {
+            alert('File content not found.');
+        }
+    }
+
+    function displayFolderContents(folderName) {
+        if (!documentsTbody) return;
+        documentsTbody.innerHTML = ''; // Clear previous file list
+
+        // Make sure sections are visible if they were hidden by file display
+        const sectionsToHide = mainContent.querySelectorAll('section');
+        sectionsToHide.forEach(section => section.style.display = 'block'); // Or original display type
+        let fileContentDiv = document.getElementById('file-content-display');
+        if (fileContentDiv) {
+            fileContentDiv.style.display = 'none';
+        }
+
+
+        const files = demoFiles[folderName];
+        if (files) {
+            Object.keys(files).forEach(fileName => {
+                const tr = document.createElement('tr');
+                tr.className = 'hover:bg-[#1A2B3A] cursor-pointer'; // Add hover effect and cursor
+
+                const nameTd = document.createElement('td');
+                nameTd.className = 'whitespace-nowrap px-6 py-4 text-sm font-medium text-slate-100';
+                nameTd.textContent = fileName;
+
+                // For demo purposes, Last Modified and Size are static
+                const modifiedTd = document.createElement('td');
+                modifiedTd.className = 'whitespace-nowrap px-6 py-4 text-sm text-slate-300';
+                modifiedTd.textContent = '2024-03-10 10:00 AM'; // Static date
+
+                const sizeTd = document.createElement('td');
+                sizeTd.className = 'whitespace-nowrap px-6 py-4 text-sm text-slate-300';
+                sizeTd.textContent = '1 KB'; // Static size
+
+                tr.appendChild(nameTd);
+                tr.appendChild(modifiedTd);
+                tr.appendChild(sizeTd);
+
+                tr.addEventListener('click', () => displayFileContent(folderName, fileName));
+                documentsTbody.appendChild(tr);
+            });
+        }
+    }
+
+    function loadDemoFolders() {
+        if (!sidebarNav) return;
+        sidebarNav.innerHTML = ''; // Clear existing (should be empty from HTML modification)
+
+        Object.keys(demoFiles).forEach(folderName => {
+            const a = document.createElement('a');
+            a.href = '#'; // Prevent page navigation
+            a.className = 'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]';
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'material-icons-outlined text-slate-400';
+            iconSpan.style.fontSize = '20px';
+            iconSpan.textContent = 'folder';
+
+            a.appendChild(iconSpan);
+            a.append(` ${folderName}`); // Add folder name text node
+
+            a.addEventListener('click', (e) => {
+                e.preventDefault(); // Prevent default anchor behavior
+
+                // Remove 'bg-[#1A2B3A]' from all other links and add to current
+                document.querySelectorAll('#sidebar-nav a').forEach(link => {
+                    link.classList.remove('bg-[#1A2B3A]');
+                    link.classList.add('text-slate-300');
+                });
+                a.classList.add('bg-[#1A2B3A]');
+                a.classList.remove('text-slate-300');
+
+                displayFolderContents(folderName);
+            });
+            sidebarNav.appendChild(a);
+        });
+
+        // Optionally, display contents of the first folder by default
+        if (Object.keys(demoFiles).length > 0) {
+            const firstFolderName = Object.keys(demoFiles)[0];
+            const firstFolderLink = sidebarNav.querySelector('a');
+            if (firstFolderLink) {
+                 firstFolderLink.classList.add('bg-[#1A2B3A]'); // Highlight first folder
+                 firstFolderLink.classList.remove('text-slate-300');
+            }
+            displayFolderContents(firstFolderName);
+        }
+    }
+
+    loadDemoFolders();
+});


### PR DESCRIPTION
This commit introduces a demo file explorer feature to allow you to interact with a sample file structure before downloading the actual application.

Key changes:
- I created a `demo_files` directory within `Projects/GoldHash` containing three folders, each with a text file containing a dad joke.
- I modified `Projects/GoldHash/index.html`:
    - I removed static folder links from the sidebar.
    - I removed static file entries from the main documents table.
    - I added `id` attributes to the sidebar navigation and documents table body for JavaScript manipulation.
- I updated `Projects/GoldHash/script.js`:
    - I implemented `loadDemoFolders` to dynamically populate the sidebar with links to the demo folders.
    - I implemented `displayFolderContents` to show the files (from a hardcoded structure) of a selected demo folder in the main table.
    - I implemented `displayFileContent` to display the content (hardcoded joke) of a selected file.
    - The script initializes by loading the demo folders and displaying the contents of the first folder.
- I populated the physical demo .txt files with the corresponding dad jokes.

This provides a basic interactive demo of file navigation and viewing, enhancing your experience on the project page.