### PR TITLE
feat: Update GoldHash UI and add Logs folder

### DIFF
--- a/Projects/GoldHash/index.html
+++ b/Projects/GoldHash/index.html
@@ -2,7 +2,7 @@
 <link crossorigin="" href="https://fonts.gstatic.com/" rel="preconnect"/>
 <link as="style" href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B600%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900" onload="this.rel='stylesheet'" rel="stylesheet"/>
 <title>Demicube GoldHash - File Integrity Monitor</title>
-<link href="data:image/x-icon;base64," rel="icon" type="image/x-icon"/>
+<link href="../../assets/Demicube.png" rel="icon" type="image/x-icon"/>
 <meta charset="utf-8"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet"/>
@@ -97,7 +97,7 @@
 <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
 <div class="flex flex-col gap-2 rounded-lg border border-[#1A2B3A] bg-[#0E1923] p-6 shadow-lg">
 <p class="text-sm font-medium text-slate-400">Files Monitored</p>
-<p class="text-3xl font-bold text-slate-100">1,234</p>
+<p class="text-3xl font-bold text-slate-100" id="files-monitored-count">1,234</p>
 </div>
 <div class="flex flex-col gap-2 rounded-lg border border-[#1A2B3A] bg-[#0E1923] p-6 shadow-lg">
 <p class="text-sm font-medium text-slate-400">Files Changed</p>
@@ -105,7 +105,7 @@
 </div>
 <div class="flex flex-col gap-2 rounded-lg border border-[#1A2B3A] bg-[#0E1923] p-6 shadow-lg">
 <p class="text-sm font-medium text-slate-400">Log Size</p>
-<p class="text-3xl font-bold text-slate-100">10 MB</p>
+<p class="text-3xl font-bold text-slate-100" id="log-size-display">10 MB</p>
 </div>
 </div>
 </section>

--- a/Projects/GoldHash/script.js
+++ b/Projects/GoldHash/script.js
@@ -1,4 +1,18 @@
 console.log("script.js loaded");
+
+// Function to recursively count files
+function countFiles(data) {
+    let count = 0;
+    for (const key in data) {
+        if (data[key].type === 'file') {
+            count++;
+        } else if (data[key].type === 'folder' && data[key].children) {
+            count += countFiles(data[key].children);
+        }
+    }
+    return count;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     console.log("DOMContentLoaded event fired");
     const sidebarNav = document.getElementById('sidebar-nav');
@@ -48,6 +62,30 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     };
+
+    // Update files monitored count
+    const filesMonitoredElement = document.getElementById('files-monitored-count');
+    if (filesMonitoredElement && typeof demoFilesData !== 'undefined' && demoFilesData.demo_files && demoFilesData.demo_files.children) {
+        const totalFiles = countFiles(demoFilesData.demo_files.children);
+        filesMonitoredElement.textContent = totalFiles.toLocaleString();
+    } else {
+        console.error("Files monitored element not found or demoFilesData structure is not as expected.");
+    }
+
+    // Update Log Size display (placeholder)
+    const logSizeElement = document.getElementById('log-size-display');
+    if (logSizeElement) {
+        // This is a placeholder value.
+        // For a live application, dynamic log size updates would typically require
+        // server-side logic to calculate directory/file sizes and an API endpoint
+        // to fetch this data, or Node.js 'fs' module if running in a Node environment
+        // with direct file system access (not applicable for client-side browser JS).
+        // Since the "Logs" folder is currently just for demonstration and might only
+        // contain a .gitkeep file, we'll set a minimal representative size.
+        logSizeElement.textContent = "1 KB"; // Representing .gitkeep or minimal folder size
+    } else {
+        console.error("Log size display element not found.");
+    }
 
     let activeSubFolderLink = null;
 


### PR DESCRIPTION
This commit introduces several updates to the GoldHash project:

1.  **Created 'Logs' Folder:** I added a `Logs` folder under `Projects/GoldHash/` to store future log files. This includes a `.gitkeep` file to ensure the directory is tracked.
2.  **Updated Favicon:** I changed the website favicon to `assets/Demicube.png`.
3.  **Dynamic 'Files Monitored':** The 'Files Monitored' section now dynamically counts and displays the number of files listed in the sidebar.
4.  **Updated 'Log Size' Display:** The 'Log Size' section is updated with a placeholder value ("1 KB"). I've added a comment in `script.js` clarifying that dynamic updates would require a server-side component.

These changes enhance the GoldHash interface and prepare for future logging functionality.