### PR TITLE
Refactor: Modify sidebar to display only folders

### DIFF
--- a/Projects/GoldHash/script.js
+++ b/Projects/GoldHash/script.js
@@ -579,6 +579,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function createSidebarEntry(name, path, type, indentLevel = 0, parentContainer, isTopLevel = false, children = null) {
+        if (type === 'file') {
+            // If it's a file, don't create a sidebar entry for it.
+            // Files will be handled by displayFolderContents when a folder is clicked.
+            return;
+        }
         console.log("createSidebarEntry called for name:", name, "path:", path, "type:", type, "indentLevel:", indentLevel, "isTopLevel:", isTopLevel);
         const entryDiv = document.createElement('div');
         entryDiv.style.marginLeft = `${indentLevel * 20}px`; // Indentation


### PR DESCRIPTION
The `createSidebarEntry` function was updated to prevent files from being rendered in the sidebar. This ensures that the sidebar provides a cleaner, folder-centric navigation.

Files within selected folders will continue to be displayed in the main document viewing area as intended. This change applies to both demo content and your uploaded folders.