### PR TITLE
feat: Implement folder deletion with edit mode

### DIFF
--- a/Projects/GoldHash/index.html
+++ b/Projects/GoldHash/index.html
@@ -48,10 +48,11 @@
 <nav class="flex-grow space-y-1 overflow-y-auto" id="sidebar-nav">
 </nav>
 <div class="mt-auto space-y-2 border-t border-t-[#1A2B3A] pt-4">
-<button class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]">
+<button id="edit-folders-button" class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]">
 <span class="material-icons-outlined text-slate-400" style="font-size: 20px"> edit </span>
               Edit
             </button>
+            <span id="delete-button-placeholder"></span>
 <button id="scan-files-button" class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]">
 <span class="material-icons-outlined text-slate-400" style="font-size: 20px"> scanner </span>
               Scan


### PR DESCRIPTION
This commit introduces an "edit mode" for managing folders in GoldHash.

Key features:
- Clicking the "Edit" button now toggles an edit mode.
- In edit mode, a "Delete Selected" button appears, and checkboxes are shown next to folders in the sidebar.
- You can select one or more folders using the checkboxes.
- Clicking "Delete Selected" prompts you to confirm if you also want to remove associated log entries.
- If confirmed, selected folders are removed from the `userUploadedFolders` data structure and the sidebar.
- If log deletion is also confirmed, corresponding entries are removed from `fileLog` and `localStorage`.
- UI elements (sidebar, activity log, statistics) are updated accordingly.
- The "Delete Selected" button is enabled only when folders are selected.
- Edit mode is exited after deletion or by toggling the "Edit" button again.

The implementation includes modifications to `index.html` to add an ID to the edit button and a placeholder for the delete button, and significant updates to `script.js` to handle the new state, UI changes, and deletion logic. Styling for new elements is done via Tailwind CSS classes applied dynamically.