### PR TITLE
Fix: Resolve ReferenceError for updateSidebarView in edit mode

### DIFF
--- a/Projects/GoldHash/script.js
+++ b/Projects/GoldHash/script.js
@@ -1099,7 +1099,7 @@ function toggleFolderCheckboxes(show) {
             deleteButton.disabled = true;
         }
     }
-    updateSidebarView(); // This will trigger re-rendering of the sidebar
+    window.updateSidebarView(); // This will trigger re-rendering of the sidebar
 }
 
 // Helper function to remove a folder from a nested data structure (like userUploadedFolders)


### PR DESCRIPTION
The function toggleFolderCheckboxes was unable to resolve updateSidebarView when called from the edit button's event handler, resulting in a ReferenceError and preventing folder checkboxes from appearing.

This change modifies the call to explicitly use window.updateSidebarView(), ensuring the function is correctly resolved from the global scope.

Additionally, I verified that the existing functionality for prompting you to delete associated log entries upon folder deletion is implemented correctly and requires no changes.