### PR TITLE
feat: Implement folder removal functionality

### DIFF
--- a/Projects/GoldHash/index.html
+++ b/Projects/GoldHash/index.html
@@ -52,7 +52,10 @@
 <span class="material-icons-outlined text-slate-400" style="font-size: 20px"> edit </span>
               Edit
             </button>
-            <span id="delete-button-placeholder"></span>
+            <button id="delete-selected-folders-button" class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]" style="display: none;">
+              <span class="material-icons-outlined text-slate-400" style="font-size: 20px"> delete_sweep </span>
+              Delete Selected
+            </button>
 <button id="scan-files-button" class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:bg-[#1A2B3A]">
 <span class="material-icons-outlined text-slate-400" style="font-size: 20px"> scanner </span>
               Scan

--- a/Projects/GoldHash/logging.js
+++ b/Projects/GoldHash/logging.js
@@ -97,6 +97,43 @@ function clearLogs() {
     alert("Logs have been cleared. (logging.js)");
 }
 
+window.removeFolderEntriesFromLog = function(folderPath) {
+    if (!folderPath || typeof folderPath !== 'string') {
+        console.error("removeFolderEntriesFromLog: Invalid folderPath provided.", folderPath);
+        return;
+    }
+    console.log(`Attempting to remove log entries for folder: "${folderPath}" (logging.js)...`);
+    const originalLogLength = window.fileLog.length;
+
+    // Filter out entries that are within the folder (path starts with folderPath + '/')
+    // Also filter out entries that match the folderPath itself (in case a folder path was somehow logged as a file)
+    window.fileLog = window.fileLog.filter(entry => {
+        return !entry.currentPath.startsWith(folderPath + '/') && entry.currentPath !== folderPath;
+    });
+
+    const removedCount = originalLogLength - window.fileLog.length;
+    if (removedCount > 0) {
+        console.log(`Removed ${removedCount} log entries associated with folder "${folderPath}" (logging.js).`);
+        saveLogsToStorage(); // Persist the changes
+
+        // Update UI elements that depend on fileLog
+        if (typeof updateFileMonitoredCount === 'function') {
+            updateFileMonitoredCount();
+            console.log("Called updateFileMonitoredCount from removeFolderEntriesFromLog (logging.js).");
+        }
+        if (typeof updateLogSizeDisplayOnLoad === 'function') { // Or a more direct size update if available
+            updateLogSizeDisplayOnLoad();
+            console.log("Called updateLogSizeDisplayOnLoad from removeFolderEntriesFromLog (logging.js).");
+        }
+        if (typeof displayActivityLog === 'function') {
+            displayActivityLog();
+            console.log("Called displayActivityLog from removeFolderEntriesFromLog (logging.js).");
+        }
+    } else {
+        console.log(`No log entries found or removed for folder "${folderPath}" (logging.js).`);
+    }
+};
+
 // --- File Scanning Function (moved from script.js) ---
 async function scanFiles() {
     console.log("Starting file scan (logging.js)...");


### PR DESCRIPTION
This commit introduces the ability for you to remove monitored folders from the application.

Key changes:

- Modified `index.html` to add a 'Delete Selected' button, initially hidden, in the sidebar controls.
- Enhanced `ui.js`:
    - Implemented an 'edit mode' toggle via the 'Edit Folders' button.
    - In edit mode, checkboxes are displayed next to top-level folders in the sidebar.
    - The 'Delete Selected' button, when clicked in edit mode, removes selected *user-added* folders from `window.userUploadedFolders`. Demo folders are not deleted.
    - UI elements (sidebar, file counts, logs display) are updated upon folder deletion.
- Added `removeFolderEntriesFromLog(folderPath)` function to `logging.js`:
    - This function filters `window.fileLog` to remove all entries associated with the deleted folder's path.
    - Changes to `window.fileLog` are persisted to local storage.
    - Relevant UI components are refreshed to reflect the updated log data.

The functionality allows you to manage your monitored folders more effectively by removing those you no longer wish to track.