### PR TITLE
feat: Improve file identification and handling

### DIFF
--- a/Projects/GoldHash/ui.js
+++ b/Projects/GoldHash/ui.js
@@ -132,6 +132,12 @@ function displayActivityLog() {
                 statusTd.classList.add('text-green-400');
                 break;
             // No 'Not Scanned' case needed here as fileLog only contains scanned files
+            case 'path_updated': // New status
+                statusTd.classList.add('text-purple-400'); // Example color
+                break;
+            case 'duplicate': // New status
+                statusTd.classList.add('text-cyan-400'); // Example color
+                break;
             default:
                 statusTd.classList.add('text-slate-300');
         }
@@ -192,6 +198,13 @@ function displayLoggedFiles(logEntriesToDisplay) {
                 break;
             case 'Not Scanned': // Handle "Not Scanned" status
                 statusTd.classList.add('text-gray-500'); // Or any other appropriate color
+                break;
+            // ADD NEW CASES HERE:
+            case 'path_updated': // New status
+                statusTd.classList.add('text-purple-400'); // Example color
+                break;
+            case 'duplicate': // New status
+                statusTd.classList.add('text-cyan-400'); // Example color
                 break;
             default:
                 statusTd.classList.add('text-slate-300');


### PR DESCRIPTION
I've implemented a more robust file identification logic in `scanFiles` within `logging.js` to address issues with duplicate, renamed, and modified files.

Key changes:
- Files are now primarily identified by a combination of path and content hash.
- When I scan a new file path, I check its hash against existing log entries:
  - If the hash matches an existing entry whose original path is no longer part of the current scan, I update the existing entry's path (status: 'path_updated'), and log the old path in `previousPaths`. This handles renamed or moved files.
  - If the hash matches an existing entry whose original path *is* still part of the current scan, I log the new path as a separate entry with status 'duplicate'. This handles cases where the exact same file content exists at multiple accessible paths.
  - If the hash does not match any existing entry, I mark the file as 'newly_added'.
- I've maintained the existing logic for 'modified' (same path, different hash) and 'verified' (same path, same hash) files, and it now works more accurately in conjunction with the new detection mechanisms.
- I've introduced new log entry statuses: 'path_updated' and 'duplicate'.
- I've updated `ui.js` so you'll see these new statuses with distinct colors in the activity log and file tables ('path_updated': purple, 'duplicate': cyan).
- I've updated alert messages in `logging.js` to reflect new count categories (paths updated, duplicates found).

This resolves inconsistencies where:
- Uploading subfolders or overlapping folders created misleading duplicate entries.
- Renaming files resulted in orphaned old entries and new entries for the same content.
- Modified files were sometimes misidentified if their path context changed.