### PR TITLE
Fix: Prevent duplicate files from being logged and added to activity

### DIFF
--- a/Projects/GoldHash/logging.js
+++ b/Projects/GoldHash/logging.js
@@ -282,22 +282,11 @@ async function scanFiles() {
                 } else {
                     // Scenario B: Duplicate/Alternate Path
                     // The path previously associated with this hash IS ALSO in the current scan list. This is a duplicate.
-                    console.warn(`DUPLICATE: File ${fileItem.path} has same content as ${hashMatchEntry.currentPath}. Creating new entry with 'duplicate' status.`);
-                    const appID = generateAppUniqueID();
-                    const newLogEntry = {
-                        appID: appID,
-                        currentPath: fileItem.path,
-                        initialDiscoveryTime: currentTime,
-                        lastHashCheckTime: currentTime,
-                        lastModifiedSystem: currentTime,
-                        currentHash: currentHash,
-                        hashHistory: [],
-                        previousPaths: [], // Initialize for new duplicate entry
-                        status: 'duplicate', // New status
-                        originalPath: hashMatchEntry.currentPath // Optional: link to the original
-                    };
-                    window.fileLog.push(newLogEntry);
-                    duplicatesFound++;
+                    // Per new requirement, we do not log this specific type of duplicate in scanFiles.
+                    // The pre-scan during folder upload should handle identifying and preventing addition of such duplicates.
+                    console.warn(`DUPLICATE (Scenario B): File ${fileItem.path} has same content as ${hashMatchEntry.currentPath}. This duplicate will not be added to the log by scanFiles.`);
+                    // window.fileLog.push(newLogEntry); // REMOVED
+                    duplicatesFound++; // Still count it for the scan summary, but no new log entry.
                 }
             } else {
                 // Hash not found - this is a genuinely new file.


### PR DESCRIPTION
This commit addresses an issue where duplicate files uploaded by you were being added to the activity log.

The solution involves two main changes:

1.  **Pre-scan on Upload (`ui.js`):** When you upload a folder, the files are now pre-scanned. Each file's content is hashed, and this hash is checked against the existing `fileLog`.
    - If all files in an upload batch are duplicates of existing logged files, you are notified, and none of the files are added.
    - If some files are new and some are duplicates, you are notified, and only the new (non-duplicate) files are added to the `userUploadedFolders` structure for subsequent scanning.
    - This prevents duplicates from being part of the active dataset for the main scan.

2.  **Modify `scanFiles` Logic (`logging.js`):** The `scanFiles` function was modified to no longer add a new log entry if it encounters a file whose hash matches an existing log entry AND that existing entry's path is also part of the current scan (previously "Scenario B: Duplicate/Alternate Path"). This serves as a safeguard, ensuring that such duplicates are not re-added to the `fileLog`, even if they somehow bypassed the pre-scan.

The `displayActivityLog` function in `ui.js` was reviewed and required no changes, as it correctly reflects the contents of `fileLog`, which will now be free of these unwanted duplicate entries.

These changes ensure that duplicate files are not added to the activity log or the main file log, providing a cleaner and more accurate experience for you.