### PR TITLE
feat: Implement persistent tracking for file change statistics

### DIFF
--- a/Projects/GoldHash/index.html
+++ b/Projects/GoldHash/index.html
@@ -127,7 +127,7 @@
 </div>
 <div class="flex flex-col gap-2 rounded-lg border border-[#1A2B3A] bg-[#0E1923] p-6 shadow-lg">
 <p class="text-sm font-medium text-slate-400">Files Changed</p>
-<p class="text-3xl font-bold text-slate-100">56</p>
+<p class="text-3xl font-bold text-slate-100" id="files-changed-count">56</p>
 </div>
 <div class="flex flex-col gap-2 rounded-lg border border-[#1A2B3A] bg-[#0E1923] p-6 shadow-lg">
 <p class="text-sm font-medium text-slate-400">Log Size</p>
@@ -141,7 +141,7 @@
 <div class="flex items-baseline justify-between">
 <div>
 <p class="text-sm font-medium text-slate-400">Total Changes</p>
-<p class="text-3xl font-bold text-slate-100">56</p>
+<p class="text-3xl font-bold text-slate-100" id="total-changes-count">56</p>
 </div>
 <div class="flex items-center gap-1">
 <p class="text-sm text-slate-400">Last 30 Days</p>

--- a/Projects/GoldHash/ui.js
+++ b/Projects/GoldHash/ui.js
@@ -49,9 +49,20 @@ window.demoFilesData = { // Moved from DOMContentLoaded
 // --- UI Display and Update Functions ---
 
 function updateFilesChangedCount(count) {
-    const filesChangedElement = document.querySelector('div.grid div:nth-child(2) p.text-3xl');
+    const filesChangedElement = document.getElementById('files-changed-count');
     if (filesChangedElement) {
         filesChangedElement.textContent = count.toLocaleString();
+    } else {
+        console.warn("Element with ID 'files-changed-count' not found.");
+    }
+}
+
+function updateTotalChangesCount(count) {
+    const totalChangesElement = document.getElementById('total-changes-count');
+    if (totalChangesElement) {
+        totalChangesElement.textContent = count.toLocaleString();
+    } else {
+        console.warn("Element with ID 'total-changes-count' not found.");
     }
 }
 


### PR DESCRIPTION
This commit introduces persistent tracking and display for two key statistics:
- 'Files Changed': The total number of unique files that have ever been modified.
- 'Total Changes': The total count of all modification events across all files.

Previously, these statistics would reset or only reflect changes from the last scan.

Changes include:
- Added `modificationHistory` array to each file entry in `fileLog` to record timestamps and previous hashes for each modification.
- Updated `logging.js` to:
    - Populate `modificationHistory` when a file's hash changes during a scan.
    - Calculate `totalUniqueFilesChanged` (based on non-empty `modificationHistory`) and `totalModificationEvents` (sum of all history entries).
    - These counts are initialized on log load, updated after each scan, and reset when logs are cleared.
    - Values are stored in global variables (`window.totalUniqueFilesChanged`, `window.totalModificationEvents`) and persisted via `localStorage` as part of `fileLog`.
- Updated `ui.js`:
    - Modified `updateFilesChangedCount` to display `window.totalUniqueFilesChanged` and target the new ID `files-changed-count`.
    - Created `updateTotalChangesCount` to display `window.totalModificationEvents` and target the new ID `total-changes-count`.
- Modified `index.html`:
    - Added `id="files-changed-count"` to the 'Files Changed' statistic element.
    - Added `id="total-changes-count"` to the 'Total Changes' statistic element.

These changes ensure that the file change statistics are now accurate, persistent across sessions, and correctly reflect the history of modifications even if files are later verified without further changes.