### PR TITLE
Fix: Display last modified date correctly in Documents tab

### DIFF
--- a/Projects/GoldHash/ui.js
+++ b/Projects/GoldHash/ui.js
@@ -479,6 +479,7 @@ function displayFolderContents(folderPath) {
                 fileDisplayData.status = loggedFile.status;
                 fileDisplayData.currentHash = loggedFile.currentHash;
                 fileDisplayData.lastHashCheckTime = loggedFile.lastHashCheckTime;
+                fileDisplayData.lastModifiedSystem = loggedFile.lastModifiedSystem;
             }
             filesForDisplay.push(fileDisplayData);
         }


### PR DESCRIPTION
The 'Last Modified' column in the 'Documents' tab was showing 'N/A' even when the information was available in the activity log.

This was because the `displayFolderContents` function in `ui.js` was not copying the `lastModifiedSystem` property from the `fileLog` entry to the `fileDisplayData` object used to render the 'Documents' tab.

The fix ensures that `fileDisplayData.lastModifiedSystem` is populated if the file exists in `fileLog`, allowing `displayLoggedFiles` to correctly render the date.