### PR TITLE
Fix: Correct DnDemicube project link path

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
               ></div>
               <p class="text-[#141414] text-base font-medium leading-normal">GoldHash</p>
             </a>
-            <a href="projects/dndemicube/index.html" class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
+            <a href="/Projects/DnDemicube/index.html" class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
               <div
                 class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
                 style='background-image: url("assets/project-DnDemicube.png");'


### PR DESCRIPTION
Updated the href for the DnDemicube project to use the absolute path `/Projects/DnDemicube/index.html` as requested.