### PR TITLE
Implement dual-view campaign map with DM/player canvases

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,108 +1,42 @@
-<html>
-  <head>
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
-    <link
-      rel="stylesheet"
-      as="style"
-      onload="this.rel='stylesheet'"
-      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900&amp;family=Plus+Jakarta+Sans%3Awght%40400%3B500%3B700%3B800"
-    />
-
-    <title>The Stephen Miller</title>
-    <link rel="icon" type="image/png" href="./assets/Demicube.png">
-
-    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  </head>
-  <body>
-    <div
-      class="relative flex size-full min-h-screen flex-col bg-white justify-between group/design-root overflow-x-hidden"
-      style='font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;'
-    >
-      <div class="px-4">
-        <div class="flex items-center bg-white p-4 pb-2 justify-between">
-
-          <div class="flex w-12 items-center justify-end">
-
-          </div>
-        </div>
-        <div class="flex p-4 @container">
-          <div class="flex w-full flex-col gap-4 items-center">
-            <div class="flex gap-4 flex-col items-center">
-              <div
-                class="bg-center bg-no-repeat aspect-square bg-cover rounded-full min-h-32 w-32"
-                style='background-image: url("assets/headshot.jpg");'
-              ></div>
-              <div class="flex flex-col items-center justify-center justify-center">
-  <p class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] text-center">Stephen Miller</p>
-  <p class="text-[#757575] text-base font-normal leading-normal text-center">Full Stack Security Analyst</p>
-  <p class="text-[#757575] text-base font-normal leading-normal text-center">Whidbey Island, Washington</p>
-              </div>
+    <title>DnDemicube - DM View</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <aside class="sidebar">
+            <h2>DM Tools</h2>
+            <div class="sidebar-section">
+                <input type="file" id="uploadMapInput" accept="image/*" style="display: none;">
+                <button id="uploadMapBtn">Upload Main Map</button>
             </div>
-          </div>
-        </div>
-        <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4 text-center">
-          I’m a jack of all trades, based in the beautiful Whidbey Island area, and specializing in functional security and machine learning web design. Let's get creative!
-        </p>
-        <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Contact</h2>
-    <button onclick="window.location.href = 'mailto:thestephenmiller@me.com';" class="flex items-center justify-center gap-4 bg-gray-200 hover:bg-gray-300 text-black font-medium py-3 px-4 rounded-lg w-full min-h-14 text-base">
-          <div class="text-[#141414] flex items-center justify-center rounded-lg bg-[#f2f2f2] shrink-0 size-10" data-icon="Envelope" data-size="24px" data-weight="regular">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-              <path
-                d="M224,48H32a8,8,0,0,0-8,8V192a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A8,8,0,0,0,224,48Zm-96,85.15L52.57,64H203.43ZM98.71,128,40,181.81V74.19Zm11.84,10.85,12,11.05a8,8,0,0,0,10.82,0l12-11.05,58,53.15H52.57ZM157.29,128,216,74.18V181.82Z"
-              ></path>
-            </svg>
-          </div>
-          <p class="text-[#141414] text-base font-normal leading-normal truncate">thestephenmiller@me.com</p>
-    </button>
-    <button onclick="window.open('https://linkedIn.com/in/thestephenmiller', '_blank');" class="flex items-center justify-center gap-4 bg-gray-200 hover:bg-gray-300 text-black font-medium py-3 px-4 rounded-lg w-full min-h-14 text-base mt-2">
-      <div class="text-[#141414] flex items-center justify-center rounded-lg bg-[#f2f2f2] shrink-0 size-10" data-icon="LinkedIn" data-size="24px" data-weight="regular">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
-        </svg>
-      </div>
-      <p class="text-[#141414] text-base font-normal leading-normal truncate">linkedIn.com/in/thestephenmiller</p>
-    </button>
-        <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Projects</h2>
-        <div class="flex overflow-y-auto [-ms-scrollbar-style:none] [scrollbar-width:none] [&amp;::-webkit-scrollbar]:hidden">
-          <div class="flex items-stretch p-4 gap-3">
-            <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
-              <a href="Projects/nCode/nCode.html" class="flex h-full flex-col gap-4">
-                <div
-                  class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                  style='background-image: url("assets/project-nCode.png");'
-                ></div>
-                <p class="text-[#141414] text-base font-medium leading-normal">nCode</p>
-              </a>
+            <div class="sidebar-section">
+                <h3>Edit Map</h3>
+                <div id="editMapControls">
+                    <!-- Controls for selecting area and linking maps will go here -->
+                    <p>Select an area on the map, then upload a map to link to it.</p>
+                    <input type="file" id="uploadSubMapInput" accept="image/*" style="display: none;">
+                    <button id="linkSubMapBtn" disabled>Upload Linked Map</button>
+                </div>
             </div>
-            <a href="Projects/GoldHash/index.html" class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
-              <div
-                class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                style='background-image: url("assets/project-goldhash.png");'
-              ></div>
-              <p class="text-[#141414] text-base font-medium leading-normal">GoldHash</p>
-            </a>
-            <a href="/Projects/DnDemicube/index.html" class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
-              <div
-                class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                style='background-image: url("assets/project-DnDemicube.png");'
-              ></div>
-              <p class="text-[#141414] text-base font-medium leading-normal">DnDemicube</p>
-              <p class="text-[#757575] text-sm font-normal leading-normal">A D&D companion app for tracking character stats, dice rolls, and inventory.</p>
-            </a>
-            <div class="flex h-full flex-1 flex-col gap-4 rounded-lg min-w-60">
-              <div
-                class="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-lg flex flex-col"
-                style='background-image: url("./assets/project-comingsoon.png");'
-              ></div>
-              <p class="text-[#141414] text-base font-medium leading-normal">Coming Soon!</p>
+            <div class="sidebar-section">
+                <button id="openPlayerViewBtn">Open Player View</button>
             </div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <div class="h-5 bg-white"></div>
-      </div>
+            <div class="sidebar-section">
+                <h3>Campaign Data</h3>
+                <button id="saveCampaignBtn">Save Campaign</button>
+                <input type="file" id="loadCampaignInput" accept=".json" style="display: none;">
+                <button id="loadCampaignBtn">Load Campaign</button>
+            </div>
+        </aside>
+        <main class="main-content">
+            <canvas id="dmCanvas"></canvas>
+        </main>
     </div>
-  </body>
+    <script src="script.js"></script>
+</body>
 </html>

--- a/player.html
+++ b/player.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DnDemicube - Player View</title>
+    <link rel="stylesheet" href="style.css"> <!-- Can reuse or create specific player styles -->
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden; /* Prevent scrollbars on body */
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background-color: #333; /* Darker background for player view */
+        }
+        #playerCanvas {
+            max-width: 100vw;
+            max-height: calc(100vh - 40px); /* Adjust for back button */
+            object-fit: contain;
+            border: 1px solid #555;
+        }
+        #playerControls {
+            position: absolute;
+            top: 5px;
+            left: 5px;
+            z-index: 10;
+        }
+        #playerControls button {
+            padding: 5px 10px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+            display: none; /* Hidden by default */
+        }
+        #playerControls button:hover {
+            background-color: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div id="playerControls">
+        <button id="backToMainMapBtn">Back to Main Map</button>
+    </div>
+    <canvas id="playerCanvas"></canvas>
+    <script src="player.js"></script>
+</body>
+</html>

--- a/player.js
+++ b/player.js
@@ -1,0 +1,118 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const playerCanvas = document.getElementById('playerCanvas');
+    const ctx = playerCanvas.getContext('2d');
+    const backToMainMapBtn = document.getElementById('backToMainMapBtn');
+
+    let mainMapImageDataUrl = null; // Store the main map
+    let currentMapImage = null; // This will hold the Image object of the currently displayed map
+    let currentMapType = 'main'; // 'main' or 'subMap'
+
+    // Function to resize canvas to fit image and window
+    function resizeAndDrawPlayerCanvas(image, mapType = 'main') {
+        const maxWidth = window.innerWidth;
+        const maxHeight = window.innerHeight;
+
+        let newWidth = image.width;
+        let newHeight = image.height;
+
+        // Adjust size if image is larger than window
+        if (newWidth > maxWidth) {
+            newHeight = (maxWidth / newWidth) * newHeight;
+            newWidth = maxWidth;
+        }
+        if (newHeight > maxHeight) {
+            newWidth = (maxHeight / newHeight) * newWidth;
+            newHeight = maxHeight;
+        }
+
+        playerCanvas.width = newWidth;
+        playerCanvas.height = newHeight;
+
+        ctx.drawImage(image, 0, 0, playerCanvas.width, playerCanvas.height);
+    }
+
+    window.addEventListener('message', (event) => {
+        // For security, you might want to check event.origin in a real application
+        // if (event.origin !== 'expected-origin') return;
+
+        const data = event.data;
+
+        if (data && data.type === 'loadMap' && data.imageDataUrl) { // Main map
+            mainMapImageDataUrl = data.imageDataUrl; // Save main map
+            const newImg = new Image();
+            newImg.onload = () => {
+                currentMapImage = newImg;
+                resizeAndDrawPlayerCanvas(currentMapImage, 'main');
+                backToMainMapBtn.style.display = 'none'; // Hide back button on main map
+                currentMapType = 'main';
+            };
+            newImg.onerror = () => {
+                console.error("Player view: Error loading main map image.");
+                ctx.clearRect(0,0, playerCanvas.width, playerCanvas.height);
+                ctx.fillText("Error loading map. DM may need to resend.", 10, 50);
+            };
+            newImg.src = mainMapImageDataUrl;
+
+        } else if (data && data.type === 'loadSubMap' && data.imageDataUrl) { // Sub map
+            const newSubImg = new Image();
+            newSubImg.onload = () => {
+                currentMapImage = newSubImg;
+                resizeAndDrawPlayerCanvas(currentMapImage, 'subMap');
+                if (mainMapImageDataUrl) { // Only show back button if main map exists
+                    backToMainMapBtn.style.display = 'block';
+                }
+                currentMapType = 'subMap';
+            };
+            newSubImg.onerror = () => {
+                console.error(`Player view: Error loading sub-map image: ${data.mapName || data.mapId}`);
+                // Don't clear canvas, keep showing previous map or main map
+                alert("Error loading the requested detailed map. Please inform the DM.");
+            };
+            newSubImg.src = data.imageDataUrl;
+            console.log(`Player view received submap: ${data.mapName || data.mapId}`);
+        }
+    });
+
+    backToMainMapBtn.addEventListener('click', () => {
+        if (mainMapImageDataUrl) {
+            const mainImg = new Image();
+            mainImg.onload = () => {
+                currentMapImage = mainImg;
+                resizeAndDrawPlayerCanvas(currentMapImage, 'main');
+                backToMainMapBtn.style.display = 'none';
+                currentMapType = 'main';
+            };
+            mainImg.onerror = () => { // Should ideally not happen if it loaded once
+                console.error("Player view: Error reloading main map image.");
+                ctx.clearRect(0,0, playerCanvas.width, playerCanvas.height);
+                ctx.fillText("Error reloading main map.", 10, 50);
+            };
+            mainImg.src = mainMapImageDataUrl;
+            console.log("Player view: Navigating back to main map.");
+        }
+    });
+
+    window.addEventListener('resize', () => {
+        if (currentMapImage) {
+            resizeAndDrawPlayerCanvas(currentMapImage, currentMapType);
+        } else {
+            // Optional: handle empty state if no map yet
+            playerCanvas.width = window.innerWidth * 0.9; // Default size
+            playerCanvas.height = window.innerHeight * 0.9;
+            ctx.clearRect(0, 0, playerCanvas.width, playerCanvas.height);
+            ctx.fillStyle = "#555";
+            ctx.font = "16px sans-serif";
+            ctx.textAlign = "center";
+            ctx.fillText("Waiting for map from DM...", playerCanvas.width / 2, playerCanvas.height / 2);
+            backToMainMapBtn.style.display = 'none';
+        }
+    });
+
+    // Initial canvas setup
+    window.dispatchEvent(new Event('resize'));
+
+    // Notify DM window that player view is ready
+    if (window.opener && !window.opener.closed) {
+        window.opener.postMessage({ type: 'playerViewReady' }, '*');
+    }
+});

--- a/script.js
+++ b/script.js
@@ -1,0 +1,388 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const uploadMapInput = document.getElementById('uploadMapInput');
+    const uploadMapBtn = document.getElementById('uploadMapBtn');
+    const dmCanvas = document.getElementById('dmCanvas');
+    const ctx = dmCanvas.getContext('2d');
+
+    const openPlayerViewBtn = document.getElementById('openPlayerViewBtn');
+    const linkSubMapBtn = document.getElementById('linkSubMapBtn');
+    const uploadSubMapInput = document.getElementById('uploadSubMapInput');
+    const saveCampaignBtn = document.getElementById('saveCampaignBtn');
+    const loadCampaignBtn = document.getElementById('loadCampaignBtn');
+    const loadCampaignInput = document.getElementById('loadCampaignInput');
+
+    let playerWindow = null;
+    let mainMapImage = null;
+    let isSelectingArea = false;
+    let selectionRect = { startX: 0, startY: 0, endX: 0, endY: 0 };
+    let currentSelection = null; // Stores the relative coordinates {x,y,w,h} of the most recent selection
+
+    let campaignData = {
+        mainMap: null, // dataURL
+        linkedAreas: [] // Array of objects: { id: uniqueId, selection: {x,y,w,h}, subMapDataUrl: dataURL, subMapName: string }
+    };
+
+
+    // Function to resize canvas to fit image and container
+    function resizeCanvas(image) {
+        const mainContent = document.querySelector('.main-content');
+        const maxWidth = mainContent.clientWidth;
+        const maxHeight = mainContent.clientHeight;
+
+        let newWidth = image.width;
+        let newHeight = image.height;
+
+        // Adjust size if image is larger than container
+        if (newWidth > maxWidth) {
+            newHeight = (maxWidth / newWidth) * newHeight;
+            newWidth = maxWidth;
+        }
+        if (newHeight > maxHeight) {
+            newWidth = (maxHeight / newHeight) * newWidth;
+            newHeight = maxHeight;
+        }
+
+        dmCanvas.width = newWidth;
+        dmCanvas.height = newHeight;
+
+        // Center the canvas if it's smaller than the container
+        dmCanvas.style.marginLeft = `${(mainContent.clientWidth - newWidth) / 2}px`;
+        dmCanvas.style.marginTop = `${(mainContent.clientHeight - newHeight) / 2}px`;
+
+        drawDmMap(); // Use a dedicated function to draw map and selection
+    }
+
+    function drawDmMap() {
+        if (!mainMapImage) return;
+        ctx.clearRect(0, 0, dmCanvas.width, dmCanvas.height);
+        ctx.drawImage(mainMapImage, 0, 0, dmCanvas.width, dmCanvas.height);
+
+        // Draw all linked areas
+        campaignData.linkedAreas.forEach(area => {
+            ctx.strokeStyle = 'green'; // Color for existing linked areas
+            ctx.lineWidth = 2;
+            ctx.strokeRect(
+                area.selection.x * dmCanvas.width,
+                area.selection.y * dmCanvas.height,
+                area.selection.w * dmCanvas.width,
+                area.selection.h * dmCanvas.height
+            );
+        });
+
+        // Draw current selection if it's different from already linked areas (or being newly drawn)
+        if (currentSelection && !campaignData.linkedAreas.find(la => la.selection === currentSelection)) {
+            ctx.strokeStyle = 'blue'; // Blue for a new, unlinked selection
+            ctx.lineWidth = 2;
+            ctx.strokeRect(
+                currentSelection.x * dmCanvas.width,
+                currentSelection.y * dmCanvas.height,
+                currentSelection.w * dmCanvas.width,
+                currentSelection.h * dmCanvas.height
+            );
+        }
+
+        // Draw ongoing selection (the red rectangle while dragging)
+        if (isSelectingArea) {
+            ctx.strokeStyle = 'red';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.rect(
+                selectionRect.startX,
+                selectionRect.startY,
+                selectionRect.endX - selectionRect.startX,
+                selectionRect.endY - selectionRect.startY
+            );
+            ctx.stroke();
+        }
+    }
+
+    // Handle main map upload
+    uploadMapBtn.addEventListener('click', () => {
+        uploadMapInput.click();
+    });
+
+    uploadMapInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                mainMapImage = new Image();
+                mainMapImage.onload = () => {
+                    resizeCanvas(mainMapImage);
+                    // If player window is open and ready, send the map
+                    if (playerWindow && !playerWindow.closed && campaignData.mainMap) { // campaignData.mainMap set here
+                         // Check if player is ready or send on 'playerViewReady'
+                        playerWindow.postMessage({ type: 'loadMap', imageDataUrl: campaignData.mainMap, mapId: 'main' }, '*');
+                    }
+                    campaignData.mainMap = mainMapImage.src; // Store in campaign data
+                    currentSelection = null;
+                    campaignData.linkedAreas = []; // Clear linked areas for new main map
+                    linkSubMapBtn.disabled = true;
+                    drawDmMap(); // Redraw to clear old selections
+                };
+                mainMapImage.onerror = () => {
+                    alert("Error: Could not load the main map image. Please try a different file.");
+                    mainMapImage = null;
+                    campaignData.mainMap = null;
+                    uploadMapInput.value = ''; // Reset file input
+                    drawDmMap(); // Clear canvas or show placeholder
+                };
+                mainMapImage.src = e.target.result; // This also becomes campaignData.mainMap via onload
+            };
+            reader.readAsDataURL(file);
+        }
+    });
+
+    // Campaign Save and Load
+    saveCampaignBtn.addEventListener('click', () => {
+        if (!campaignData.mainMap) {
+            alert("Please upload a main map before saving.");
+            return;
+        }
+        const campaignJson = JSON.stringify(campaignData, null, 2);
+        const blob = new Blob([campaignJson], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `dndemicube-campaign-${Date.now()}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        console.log("Campaign saved.");
+    });
+
+    loadCampaignBtn.addEventListener('click', () => {
+        loadCampaignInput.click();
+    });
+
+    loadCampaignInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                try {
+                    const loadedData = JSON.parse(e.target.result);
+                    if (loadedData && loadedData.mainMap && Array.isArray(loadedData.linkedAreas)) {
+                        campaignData = loadedData;
+
+                        // Restore main map
+                        mainMapImage = new Image();
+                        mainMapImage.onload = () => {
+                            resizeCanvas(mainMapImage); // This will also call drawDmMap
+                            // If player window is open and ready, send the newly loaded main map
+                            if (playerWindow && !playerWindow.closed) {
+                                playerWindow.postMessage({ type: 'loadMap', imageDataUrl: campaignData.mainMap, mapId: 'main' }, '*');
+                            }
+                        };
+                        mainMapImage.onerror = () => {
+                            alert("Error: Could not load the main map image from the campaign file. The campaign data might be corrupted or the image source invalid.");
+                            // Reset to a clean state
+                            mainMapImage = null;
+                            campaignData.mainMap = null;
+                            campaignData.linkedAreas = [];
+                            drawDmMap();
+                        };
+                        mainMapImage.src = campaignData.mainMap;
+
+                        currentSelection = null;
+                        linkSubMapBtn.disabled = true;
+
+                        console.log("Campaign loaded:", campaignData);
+                        // drawDmMap() is called within resizeCanvas -> mainMapImage.onload
+                    } else {
+                        alert("Invalid campaign file format.");
+                    }
+                } catch (error) {
+                    console.error("Error loading campaign:", error);
+                    alert("Failed to load campaign file. It might be corrupted or not a valid JSON.");
+                } finally {
+                    loadCampaignInput.value = ''; // Reset file input
+                }
+            };
+            reader.readAsText(file);
+        }
+    });
+    // Area Selection Logic
+    dmCanvas.addEventListener('mousedown', (e) => {
+        if (!mainMapImage) return; // Only allow selection if a map is loaded
+        isSelectingArea = true;
+        const rect = dmCanvas.getBoundingClientRect();
+        selectionRect.startX = e.clientX - rect.left;
+        selectionRect.startY = e.clientY - rect.top;
+        selectionRect.endX = e.clientX - rect.left;
+        selectionRect.endY = e.clientY - rect.top;
+        // console.log('Mouse down:', selectionRect);
+
+        // Check if click is on a linked area
+        if (!isSelectingArea && mainMapImage) { // Only check for clicks if not currently drawing a new selection
+            const clickX = selectionRect.startX; // mousedown already recorded these
+            const clickY = selectionRect.startY;
+
+            for (const area of campaignData.linkedAreas) {
+                const areaRect = {
+                    x: area.selection.x * dmCanvas.width,
+                    y: area.selection.y * dmCanvas.height,
+                    w: area.selection.w * dmCanvas.width,
+                    h: area.selection.h * dmCanvas.height
+                };
+
+                if (clickX >= areaRect.x && clickX <= areaRect.x + areaRect.w &&
+                    clickY >= areaRect.y && clickY <= areaRect.y + areaRect.h) {
+
+                    console.log(`Clicked linked area: ${area.id}, sending to player view.`);
+                    if (playerWindow && !playerWindow.closed) {
+                        playerWindow.postMessage({
+                            type: 'loadSubMap',
+                            imageDataUrl: area.subMapDataUrl,
+                            mapId: area.id, // Unique ID for this sub-map view
+                            mapName: area.subMapName
+                        }, '*');
+                    }
+                    // Potentially highlight the clicked area on DM map or provide other feedback
+                    return; // Stop further processing if a linked area was clicked
+                }
+            }
+        }
+    });
+
+    dmCanvas.addEventListener('mousemove', (e) => {
+        if (!isSelectingArea || !mainMapImage) return;
+        const rect = dmCanvas.getBoundingClientRect();
+        selectionRect.endX = e.clientX - rect.left;
+        selectionRect.endY = e.clientY - rect.top;
+        drawDmMap(); // Redraw map and current selection rectangle
+        // console.log('Mouse move:', selectionRect);
+    });
+
+    dmCanvas.addEventListener('mouseup', (e) => {
+        if (!isSelectingArea || !mainMapImage) return;
+        isSelectingArea = false;
+        const rect = dmCanvas.getBoundingClientRect();
+        selectionRect.endX = e.clientX - rect.left;
+        selectionRect.endY = e.clientY - rect.top;
+
+        // Normalize coordinates (ensure start is top-left)
+        const x = Math.min(selectionRect.startX, selectionRect.endX);
+        const y = Math.min(selectionRect.startY, selectionRect.endY);
+        const width = Math.abs(selectionRect.endX - selectionRect.startX);
+        const height = Math.abs(selectionRect.endY - selectionRect.startY);
+
+        if (width > 5 && height > 5) { // Minimum selection size
+            // Store selection as relative coordinates (percentages)
+            currentSelection = {
+                x: x / dmCanvas.width,
+                y: y / dmCanvas.height,
+                w: width / dmCanvas.width,
+                h: height / dmCanvas.height
+            };
+            linkSubMapBtn.disabled = false; // Enable button to link a sub-map
+            console.log('Area selected (relative):', currentSelection);
+        } else {
+            currentSelection = null;
+            linkSubMapBtn.disabled = true;
+            console.log('Selection too small.');
+        }
+        drawDmMap(); // Redraw to show final selection in blue or clear it
+    });
+
+    dmCanvas.addEventListener('mouseleave', () => {
+        // Optional: Cancel selection if mouse leaves canvas while selecting
+        // if (isSelectingArea) {
+        //     isSelectingArea = false;
+        //     currentSelection = null;
+        //     linkSubMapBtn.disabled = true;
+        //     drawDmMap();
+        //     console.log('Selection cancelled (mouse left canvas)');
+        // }
+    });
+
+
+    // Open Player View
+    openPlayerViewBtn.addEventListener('click', () => {
+        if (playerWindow && !playerWindow.closed) {
+            playerWindow.focus();
+        } else {
+            playerWindow = window.open('player.html', 'PlayerView', 'width=800,height=600');
+            // Map will be sent once player window signals readiness (see message listener below)
+        }
+    });
+
+    window.addEventListener('message', (event) => {
+        // Potentially check event.origin for security here
+        if (event.source === playerWindow && event.data && event.data.type === 'playerViewReady') {
+            console.log("Player view is ready. Sending main map if available.");
+            if (mainMapImage && playerWindow && !playerWindow.closed) {
+                playerWindow.postMessage({ type: 'loadMap', imageDataUrl: campaignData.mainMap, mapId: 'main' }, '*');
+            }
+        }
+    });
+
+    // Ensure canvas resizes with window and redraws map and selection
+    window.addEventListener('resize', () => {
+        if (mainMapImage) {
+            resizeCanvas(mainMapImage); // This will call drawDmMap
+        } else {
+            // If no image, clear canvas and keep it centered (or at default size)
+            const mainContent = document.querySelector('.main-content');
+            dmCanvas.width = mainContent.clientWidth * 0.9; // Example: 90% of container
+            dmCanvas.height = mainContent.clientHeight * 0.9;
+            dmCanvas.style.marginLeft = `${(mainContent.clientWidth - dmCanvas.width) / 2}px`;
+            dmCanvas.style.marginTop = `${(mainContent.clientHeight - dmCanvas.height) / 2}px`;
+            ctx.clearRect(0, 0, dmCanvas.width, dmCanvas.height); // Clear canvas
+            currentSelection = null; // Clear selection if no map
+            linkSubMapBtn.disabled = true;
+        }
+    });
+
+    // Initial canvas setup (e.g., placeholder or empty state)
+    // Call resize on load to set initial canvas size
+    window.dispatchEvent(new Event('resize'));
+
+    // Handle Sub-map upload
+    linkSubMapBtn.addEventListener('click', () => {
+        if (!currentSelection) {
+            alert("Please select an area on the main map first.");
+            return;
+        }
+        uploadSubMapInput.click();
+    });
+
+    uploadSubMapInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if (file && currentSelection) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const subMapImage = new Image();
+                subMapImage.onload = () => {
+                    const subMapDataUrl = subMapImage.src; // Use the image src after successful load
+                    const newLinkedArea = {
+                        id: `area-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`, // Unique ID
+                        selection: currentSelection, // This is the relative one
+                        subMapDataUrl: subMapDataUrl,
+                        subMapName: file.name
+                    };
+                    campaignData.linkedAreas.push(newLinkedArea);
+
+                    console.log('Sub-map linked:', newLinkedArea);
+                    console.log('All linked areas:', campaignData.linkedAreas);
+
+                    // Reset currentSelection and disable button to prevent accidental relink of same area
+                    currentSelection = null;
+                    linkSubMapBtn.disabled = true;
+                    uploadSubMapInput.value = ''; // Reset file input
+
+                    drawDmMap(); // Redraw to show new linked area (e.g., in green)
+                };
+                subMapImage.onerror = () => {
+                    alert(`Error: Could not load the sub-map image "${file.name}". Please try a different file.`);
+                    uploadSubMapInput.value = ''; // Reset file input
+                    // currentSelection remains, so DM can try uploading another file for the same selection
+                };
+                subMapImage.src = e.target.result; // Initial assignment to trigger load
+            };
+            reader.readAsDataURL(file);
+        }
+    });
+
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,96 @@
+body, html {
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+    height: 100%;
+    overflow: hidden; /* Prevent scrollbars on body */
+}
+
+.container {
+    display: flex;
+    height: 100vh; /* Full viewport height */
+}
+
+.sidebar {
+    width: 250px;
+    background-color: #f0f0f0;
+    padding: 15px;
+    box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+    overflow-y: auto; /* Allow sidebar to scroll if content exceeds height */
+    height: 100%;
+    box-sizing: border-box;
+}
+
+.sidebar h2 {
+    margin-top: 0;
+    font-size: 1.5em;
+    text-align: center;
+}
+
+.sidebar h3 {
+    margin-top: 20px;
+    margin-bottom: 10px;
+    font-size: 1.1em;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 5px;
+}
+
+.sidebar-section {
+    margin-bottom: 20px;
+}
+
+.sidebar-section button {
+    display: block;
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+.sidebar-section button:hover {
+    background-color: #0056b3;
+}
+
+.sidebar-section button:disabled {
+    background-color: #cccccc;
+    cursor: not-allowed;
+}
+
+.sidebar-section p {
+    font-size: 0.9em;
+    color: #333;
+}
+
+.main-content {
+    flex-grow: 1;
+    padding: 0; /* Remove padding if canvas is to touch edges */
+    display: flex; /* To center canvas, if needed, or manage its size */
+    justify-content: center; /* Center canvas horizontally */
+    align-items: center; /* Center canvas vertically */
+    overflow: hidden; /* Prevent main content area from causing scrollbars */
+    background-color: #e9e9e9; /* Light background for canvas area */
+}
+
+#dmCanvas {
+    max-width: 100%;
+    max-height: 100%;
+    /* The actual width and height will be set by JavaScript based on the uploaded image */
+    /* Add a border to see the canvas element before an image is loaded */
+    border: 1px solid #ccc;
+    object-fit: contain; /* Ensures the image is scaled correctly within the canvas dimensions */
+}
+
+/* Basic styles for player.html canvas */
+#playerCanvas {
+    max-width: 100%;
+    max-height: 100vh; /* Player canvas can take full viewport height */
+    display: block; /* Remove extra space below canvas */
+    margin: auto; /* Center canvas if it's smaller than window */
+    border: 1px solid #bbb;
+    object-fit: contain;
+}


### PR DESCRIPTION
Features:
- DM can upload a main map image.
- Player view window displays maps sent by DM.
- DM can select areas on the map and link other map images (sub-maps).
- Clicking a linked area in DM view sends the sub-map to player view.
- Player view includes a 'Back to Main Map' button.
- Campaign state (main map, linked areas, sub-maps) can be saved to and loaded from JSON files.
- Implemented `postMessage` for DM-player window communication.
- Added basic error handling for image loading and player window readiness.