### PR TITLE
Fix: Prevent map upload button overflow and verify image display

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -12,6 +12,8 @@
         button, input[type="file"] {
             padding: 8px 12px;
             background-color: #b6cae1;
+            max-width: 100%;
+            box-sizing: border-box;
             color: #15191e;
             border: none;
             border-radius: 4px;


### PR DESCRIPTION
- Added CSS to ensure the 'Choose File' button for map uploads does not overflow the sidebar.
- Verified that the uploaded map image is correctly displayed in the main view (dm-canvas) as per existing functionality.