### PR TITLE
Fix: Prevent active map from reverting during sub-map creation

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -210,6 +210,7 @@
         let tempSelectionCanvasRect = null;
         // Stores the image-relative area selected on currentlyViewedMap, ready for new submap creation
         let pendingSubmapArea = null;
+        let justFinalizedSelection = false; // Flag to prevent click after selection
 
 
         // --- Main Map Drawing and Handling ---
@@ -473,6 +474,7 @@
             uploadSubmapButton.value = null;
             uploadSubmapButton.focus();
 
+            justFinalizedSelection = true; // Set the flag here
             drawDmMap(); // Redraw to clear the red selection rectangle
             // Draw a temporary "pending link" blue rectangle for the confirmed area (in canvas coordinates)
             ctx.strokeStyle = 'rgba(100, 100, 255, 0.8)';
@@ -537,6 +539,10 @@
 
 // --- Canvas Click Logic for Player View Control ---
 dmCanvas.addEventListener('click', (e) => {
+    if (justFinalizedSelection) {
+        justFinalizedSelection = false; // Reset flag and prevent click action
+        return;
+    }
     if (!currentlyDisplayedImage || !currentlyDisplayedImage.complete || isSelectingArea) {
         return;
     }


### PR DESCRIPTION
When selecting an area for a new sub-map on a child map, the view would incorrectly revert to the main map after the selection was made but before the file was chosen.

This was caused by the generic canvas click handler firing after the mouseup event of the selection process. The click handler would then interpret this as a click on the background of the child map, causing it to navigate to the parent.

Introduced a 'justFinalizedSelection' flag. This flag is set to true at the end of the mouseup event when a selection is finalized. The canvas click handler now checks this flag; if true, it resets the flag and returns immediately, preventing the erroneous navigation.