### PR TITLE
Fix: Correct reselection state check in newSubmapButton

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -500,7 +500,7 @@
 
         // --- Area Selection Logic ---
         newSubmapButton.addEventListener('click', () => {
-            if (isReselectingArea) { // Don't allow new submap if reselecting
+            if (isPendingAreaReselection || isActivelyDrawingReselectedArea) { // Check both new states
                 alert("Please finish or cancel the current area reselection first.");
                 return;
             }


### PR DESCRIPTION
Updated the `newSubmapButton` event listener to check the correct state variables (`isPendingAreaReselection` or `isActivelyDrawingReselectedArea`) instead of the removed `isReselectingArea` variable.

This fixes a ReferenceError that occurred when trying to create a new submap after the reselection workflow was refactored.