### PR TITLE
Enhance map list to display images on click

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -58,9 +58,24 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     font-size: 0.9em; /* Slightly smaller than h3 */
     display: inline-block; /* Allows margin and proper positioning */
 }
-.uploaded-maps-list.edit-mode-active li:hover {
-    background-color: #2a3138; /* Subtle hover effect for items in edit mode */
+
+/* Styling for map list items */
+.map-list-item {
+    padding: 5px 2px; /* Add some padding for easier clicking */
+    border-radius: 3px;
+    margin-bottom: 2px; /* Slight spacing between items */
 }
+
+.map-list-item.clickable-map:hover {
+    background-color: #2a3138; /* Hover effect when clickable */
+    cursor: pointer;
+}
+
+/* When in edit mode, the hover effect is different (or can be non-existent if preferred) */
+.uploaded-maps-list.edit-mode-active .map-list-item:hover {
+     background-color: #313842; /* Different hover for edit mode, or remove if not desired */
+}
+
 .file-actions {
     margin-left: 10px; /* Spacing between filename and action icons */
 }


### PR DESCRIPTION
- Implemented functionality to display clicked map images on the main canvas when not in edit mode.
- Stored ObjectURLs for uploaded map files to facilitate display.
- Updated rename and delete operations to correctly manage ObjectURLs, including revoking them on deletion to prevent memory leaks.
- Added CSS for clickable map items in the list.
- Ensured this new functionality is disabled during edit mode to prevent conflicts with CRUD operations.