### PR TITLE
Implement core map tools: active list, child map linking, and overlay…

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -130,6 +130,19 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     /* Optional: Style for map names when in edit mode, e.g., different background */
     /* background-color: #3a4148; */ /* Example */
 }
+
+/* Styling for selected map items in either list */
+.selected-map-item {
+    background-color: #3a4f6a !important; /* A distinct background color for selection */
+    /* border-left: 3px solid #b6cae1; */ /* Example: a border indicator */
+    font-weight: bold; /* Make text bold */
+    color: #ffffff !important; /* Ensure text is readable */
+}
+/* Ensure hover on a selected item doesn't obscure selection, or is complementary */
+.selected-map-item:hover {
+    background-color: #4a5f7a !important; /* Slightly different hover for selected item */
+}
+
 .rename-input-active {
     /* Basic styling for the rename input field */
     padding: 2px 4px;


### PR DESCRIPTION
… persistence framework

- Adds functionality for 'Add to Active List' and 'Remove from Active List' for maps.
- Implements 'Link to Child Map' tool:
  - Allows drawing polygons on a map selected in 'Map Manager'.
  - Links this polygon to another map from 'Map Manager' as a child.
  - Stores polygon coordinates and linked map name as an overlay on the parent map.
- Overlays (child map links) are visually drawn on the canvas.
- In 'Active View', clicking a child map link polygon navigates to the child map if it's in the active list, otherwise alerts the user.
- Introduces 'detailedMapData' to store map URLs, names, and overlay arrays.
- Adds basic save/load campaign functionality:
  - Saves map definitions (name + overlays) and active view state (map names + their overlays) to a JSON file.
  - Loads these definitions back into memory.
  - Note: Re-uploading map image files after loading a campaign does not currently automatically re-apply their saved overlays; the definitions are loaded but not merged with new file uploads in this iteration.