### PR TITLE
Fix: Enable delete button for existing maps in Manage Maps

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -711,7 +711,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     deleteIcon.classList.add('file-action-icon', 'delete-map');
                     deleteIcon.title = 'Delete map';
                     deleteIcon.style.cursor = 'pointer';
-                    // deleteIcon.onclick = () => handleDelete(item); // Placeholder for delete
+                    deleteIcon.onclick = () => handleDelete(item); // Placeholder for delete
 
                     const upIcon = document.createElement('span');
                     upIcon.textContent = '↑';


### PR DESCRIPTION
This commit fixes an issue where the delete button for maps in the 'Manage Maps' section of the DM view was not functional if the maps were present before toggling into edit mode.

The `onclick` handler for the delete icon was erroneously commented out. This change uncommented the line to correctly assign the `handleDelete` function, ensuring that existing map items can be deleted when edit mode is activated.