### PR TITLE
Implement polygon context menu in DM view

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -163,3 +163,30 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     z-index: 1000; /* Ensure it's on top */
     /* display: none; is handled by inline style initially and JS */
 }
+
+/* Context Menu Styling */
+.context-menu {
+    background-color: #2a3138; /* Dark background, similar to canvas */
+    border: 1px solid #3f4c5a; /* Border similar to other elements */
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2); /* Subtle shadow for depth */
+    z-index: 1001; /* Ensure it's above the hover-label and canvas elements */
+    color: #e0e0e0; /* Light text color */
+    border-radius: 4px; /* Rounded corners */
+}
+
+.context-menu ul {
+    list-style: none;
+    padding: 5px 0;
+    margin: 0;
+}
+
+.context-menu ul li {
+    padding: 8px 15px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.context-menu ul li:hover {
+    background-color: #3f4c5a; /* Hover effect for menu items */
+    color: #b6cae1; /* Highlight text on hover */
+}

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -78,5 +78,14 @@
     <div id="hover-label" class="hover-label" style="display: none;"></div>
 
     <script src="dm_view.js"></script>
+
+    <div id="polygon-context-menu" class="context-menu" style="display: none; position: absolute;">
+        <ul>
+            <li data-action="change-child-map">Change Child Map</li>
+            <li data-action="redraw-polygon">Redraw Polygon</li>
+            <li data-action="move-polygon">Move Polygon</li>
+            <li data-action="delete-link">Delete Link</li>
+        </ul>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Adds a right-click context menu for polygons on maps selected in the 'Manage Maps' section.

Features:
- Change Child Map: Updates the map linked to a polygon.
- Redraw Polygon: Allows redrawing a polygon while keeping its link.
- Move Polygon: Enables click-and-drag functionality to reposition polygons.
- Delete Link: Removes a polygon and its associated link.

Includes state management for these interactive operations and cancellation mechanisms.