### PR TITLE
Fix: Rename resetLinkingState to resetAllInteractiveStates

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1183,12 +1183,12 @@ document.addEventListener('DOMContentLoaded', () => {
                         console.log(`Map "${clickedFileName}" linked as child to "${selectedMapInManager}". Overlay data:`, newOverlay);
                         alert(`Map "${clickedFileName}" successfully linked as a new child to "${parentMapData.name}".`);
 
-                        resetLinkingState(); // This will also call updateButtonStates and redraw the parent map
+                        resetAllInteractiveStates(); // This will also call updateButtonStates and redraw the parent map
                         displayMapOnCanvas(selectedMapInManager); // Ensure parent map shows new link
                     } else {
                         console.error("Parent map data not found for new link:", selectedMapInManager);
                         alert("Error: Could not find data for the parent map. Linking failed.");
-                        resetLinkingState();
+                        resetAllInteractiveStates();
                     }
                 } else {
                     // Normal selection behavior (displaying a map from Manage Maps)


### PR DESCRIPTION
Corrects a ReferenceError by renaming all instances of the old `resetLinkingState` function to the new `resetAllInteractiveStates` function name. This ensures consistency and resolves the error encountered during polygon linking operations.

This commit builds upon the previous work for the polygon context menu.