### PR TITLE
Refactor: Move notes editor to main canvas area

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -7,7 +7,31 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
 .tab-button.active { border-bottom-color: #b6cae1; color: #b6cae1; }
 .tab-content { display: none; }
 .tab-content.active { display: block; }
-#map-container { flex-grow: 1; display: flex; justify-content: center; align-items: center; overflow: hidden; padding: 10px; }
+
+/* Main content area containers: #map-container and #note-editor-container */
+#map-container {
+    flex-grow: 1;
+    display: flex; /* Default visible, unless .hidden is applied by JS */
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    padding: 10px;
+}
+#map-container.hidden {
+    display: none !important;
+}
+
+/* #note-editor-container has initial inline styles: display: none; flex-grow: 1; padding: 10px; */
+/* JS will toggle this class to show it and ensure flex properties */
+#note-editor-container.active {
+    display: flex !important; /* Override inline display: none */
+    flex-direction: column; /* To make #note-editor-area inside it grow */
+    /* flex-grow: 1; and padding: 10px; are already set inline */
+    /* Optional: Add border/background if it should differ from map-container or body */
+    /* border: 1px solid #3f4c5a; */
+    /* background-color: #2a3138; */
+}
+
 #dm-canvas { max-width: 100%; max-height: 100%; border: 1px solid #3f4c5a; background-color: #2a3138; }
 button, input[type="file"] {
     padding: 8px 12px;
@@ -192,10 +216,14 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 }
 
 /* Notes Tab Styles */
+/* #tab-notes no longer needs to be a flex column for the editor,
+   but keeping it block or flex for its children (controls, list) is fine.
+   Height 100% might also not be necessary if it's just for the list area,
+   which will have its own scroll. */
 #tab-notes {
-    display: flex;
-    flex-direction: column;
-    height: 100%; /* Make notes tab take full height of its container */
+    /* display: flex; */ /* Not strictly necessary anymore for editor */
+    /* flex-direction: column; */
+    /* height: 100%; */ /* Let content define its height within sidebar constraints */
 }
 
 .notes-controls {
@@ -264,11 +292,11 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 
 
 #note-editor-area {
-    flex-grow: 1; /* Takes remaining space in the notes tab */
+    flex-grow: 1; /* Takes remaining space in its container (#note-editor-container) */
     display: flex;
     flex-direction: column;
-    padding-top: 15px; /* Space above the title input */
-    overflow-y: auto; /* If content overflows */
+    /* padding-top: 15px; /* Padding is now on #note-editor-container */
+    overflow-y: hidden; /* EasyMDE handles its own scrolling */
 }
 
 #note-title-input {

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -69,15 +69,11 @@
                 <button id="create-new-note-button">Create New Note</button>
             </div>
             <div id="notes-sidebar" class="sidebar-section">
-                <ul id="notes-list" style="list-style-type: none; padding-left: 0; overflow-y: auto; max-height: 200px;">
+                <ul id="notes-list" style="list-style-type: none; padding-left: 0; overflow-y: auto; max-height: 400px;"> {/* Adjusted max-height */}
                     <!-- Notes will be listed here -->
                 </ul>
             </div>
-            <div id="note-editor-area">
-                <input type="text" id="note-title-input" placeholder="Note Title" />
-                <button id="save-note-button">Save Note</button>
-                <textarea id="markdown-editor"></textarea>
-            </div>
+            {/* Note editor area will be moved outside the sidebar */}
         </div>
 
         <div id="tab-characters" class="tab-content">
@@ -87,6 +83,13 @@
     </div>
     <div id="map-container">
         <canvas id="dm-canvas"></canvas>
+    </div>
+    <div id="note-editor-container" style="display: none; flex-grow: 1; padding: 10px;"> {/* New container for the note editor */}
+        <div id="note-editor-area" style="display: flex; flex-direction: column; height: 100%;">
+            <input type="text" id="note-title-input" placeholder="Note Title" />
+            <button id="save-note-button" style="margin-top: 5px; margin-bottom: 5px; width: auto; align-self: flex-start;">Save Note</button>
+            <textarea id="markdown-editor"></textarea>
+        </div>
     </div>
     <div id="hover-label" class="hover-label" style="display: none;"></div>
 


### PR DESCRIPTION
Moved the markdown note editor from the sidebar to the main canvas area when the 'Notes' tab is active.

- Modified HTML to relocate the note editor elements.
- Updated CSS to style the editor in its new position and manage visibility of main content containers (map vs. notes).
- Adjusted JavaScript tab switching logic to show/hide the map container or the notes editor container in the main area based on the active tab.
- Ensured EasyMDE initialization and refresh occur correctly.