### PR TITLE
feat: Implement note linking and visibility controls

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -364,3 +364,37 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     max-width: 100%; /* Ensure images are responsive within the preview */
     height: auto;
 }
+
+.note-preview-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1002;
+}
+
+.note-preview-content {
+    background-color: #2a3138;
+    padding: 20px;
+    border-radius: 5px;
+    max-width: 80%;
+    max-height: 80%;
+    overflow-y: auto;
+    position: relative;
+}
+
+.note-preview-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: #e0e0e0;
+    cursor: pointer;
+}

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -103,5 +103,21 @@
             <li data-action="toggle-player-visibility">Toggle Player Visibility</li>
         </ul>
     </div>
+
+    <div id="note-context-menu" class="context-menu" style="display: none; position: absolute;">
+        <ul>
+            <li data-action="link-to-new-note">Link to New Note</li>
+            <li data-action="move-note">Move Note</li>
+            <li data-action="delete-link">Delete Link</li>
+            <li data-action="toggle-player-visibility">Toggle Player Visibility</li>
+        </ul>
+    </div>
+
+    <div id="note-preview-overlay" class="note-preview-overlay" style="display: none;">
+        <div class="note-preview-content">
+            <button id="note-preview-close" class="note-preview-close">&times;</button>
+            <div id="note-preview-body"></div>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces the ability for DMs to link notes to maps. It adds the following features:

- A 'Link Note' button in the DM Controls tab that allows placing note icons on the map.
- A context menu for note icons with options to 'Link to New Note', 'Move Note', and 'Delete Link'.
- Functionality to link notes to icons, move icons on the map, and delete note links.
- A note preview overlay in 'Active View' mode that displays the note content when a note icon is clicked.
- Player visibility controls for note icons, allowing the DM to show or hide them from the player's view.