### PR TITLE
fix: Implement player view note visibility and preview

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -572,8 +572,15 @@ document.addEventListener('DOMContentLoaded', () => {
                                 const notePreviewOverlay = document.getElementById('note-preview-overlay');
                                 const notePreviewBody = document.getElementById('note-preview-body');
                                 if (notePreviewOverlay && notePreviewBody) {
-                                    notePreviewBody.innerHTML = easyMDE.options.previewRender(note.content);
+                                    const renderedHTML = easyMDE.options.previewRender(note.content);
+                                    notePreviewBody.innerHTML = renderedHTML;
                                     notePreviewOverlay.style.display = 'flex';
+                                    if (playerWindow && !playerWindow.closed && overlay.playerVisible) {
+                                        playerWindow.postMessage({
+                                            type: 'showNotePreview',
+                                            content: renderedHTML
+                                        }, '*');
+                                    }
                                 }
                             }
                         }
@@ -2487,6 +2494,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const notePreviewOverlay = document.getElementById('note-preview-overlay');
             if (notePreviewOverlay) {
                 notePreviewOverlay.style.display = 'none';
+                if (playerWindow && !playerWindow.closed) {
+                    playerWindow.postMessage({ type: 'hideNotePreview' }, '*');
+                }
             }
         });
     }

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -8,11 +8,38 @@
         body { margin: 0; background-color: #15191e; display: flex; justify-content: center; align-items: center; height: 100vh; overflow: hidden; }
         #player-map-container { width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; }
         #player-canvas { max-width: 100%; max-height: 100%; border: 1px solid #3f4c5a; background-color: #2a3138;}
+        .note-preview-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 1002;
+        }
+        .note-preview-content {
+            background-color: #2a3138;
+            padding: 20px;
+            border-radius: 5px;
+            max-width: 80%;
+            max-height: 80%;
+            overflow-y: auto;
+            position: relative;
+            color: #e0e0e0;
+        }
     </style>
 </head>
 <body>
     <div id="player-map-container">
         <canvas id="player-canvas"></canvas>
+    </div>
+    <div id="note-preview-overlay" class="note-preview-overlay" style="display: none;">
+        <div class="note-preview-content">
+            <div id="note-preview-body"></div>
+        </div>
     </div>
     <script src="player_view.js"></script>
 </body>

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -83,11 +83,9 @@ function drawOverlays_PlayerView(overlays) {
 
     overlays.forEach(overlay => {
         if (overlay.type === 'childMapLink' && overlay.polygon) {
-            // Player view receives already filtered overlays (playerVisible = true by DM)
             pCtx.beginPath();
-            pCtx.strokeStyle = 'rgba(100, 100, 255, 0.4)'; // Slightly more visible blue for player links
+            pCtx.strokeStyle = 'rgba(100, 100, 255, 0.4)';
             pCtx.lineWidth = 2;
-
             overlay.polygon.forEach((point, index) => {
                 const canvasX = (point.x * currentMapDisplayData.ratio) + currentMapDisplayData.offsetX;
                 const canvasY = (point.y * currentMapDisplayData.ratio) + currentMapDisplayData.offsetY;
@@ -97,7 +95,6 @@ function drawOverlays_PlayerView(overlays) {
                     pCtx.lineTo(canvasX, canvasY);
                 }
             });
-
             if (overlay.polygon.length > 2) {
                 const firstPoint = overlay.polygon[0];
                 const firstPointCanvasX = (firstPoint.x * currentMapDisplayData.ratio) + currentMapDisplayData.offsetX;
@@ -105,6 +102,19 @@ function drawOverlays_PlayerView(overlays) {
                 pCtx.lineTo(firstPointCanvasX, firstPointCanvasY);
             }
             pCtx.stroke();
+        } else if (overlay.type === 'noteLink' && overlay.position) {
+            const iconSize = 20;
+            const canvasX = (overlay.position.x * currentMapDisplayData.ratio) + currentMapDisplayData.offsetX;
+            const canvasY = (overlay.position.y * currentMapDisplayData.ratio) + currentMapDisplayData.offsetY;
+            pCtx.fillStyle = 'rgba(102, 255, 102, 0.9)';
+            pCtx.fillRect(canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
+            pCtx.strokeStyle = 'black';
+            pCtx.strokeRect(canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
+            pCtx.fillStyle = 'black';
+            pCtx.font = `${iconSize * 0.8}px sans-serif`;
+            pCtx.textAlign = 'center';
+            pCtx.textBaseline = 'middle';
+            pCtx.fillText('📝', canvasX, canvasY);
         }
     });
 }
@@ -175,6 +185,20 @@ window.addEventListener('message', (event) => {
                 currentMapImage = null;
                 currentOverlays = [];
                 drawPlaceholder("Map cleared by DM.");
+                break;
+            case 'showNotePreview':
+                const notePreviewOverlay = document.getElementById('note-preview-overlay');
+                const notePreviewBody = document.getElementById('note-preview-body');
+                if (notePreviewOverlay && notePreviewBody && data.content) {
+                    notePreviewBody.innerHTML = data.content;
+                    notePreviewOverlay.style.display = 'flex';
+                }
+                break;
+            case 'hideNotePreview':
+                const notePreviewOverlayToHide = document.getElementById('note-preview-overlay');
+                if (notePreviewOverlayToHide) {
+                    notePreviewOverlayToHide.style.display = 'none';
+                }
                 break;
             default:
                 console.log("Player view received unhandled message type:", data.type);


### PR DESCRIPTION
This commit fixes the issue where the player view was not updated when the DM toggled note visibility or opened a note preview.

- Updates `player_view.js` to handle `showNotePreview` and `hideNotePreview` messages from the DM view.
- Updates `player_view.js` to draw note icons on the canvas.
- Updates `dm_view.js` to send note preview content and visibility updates to the player view.