### PR TITLE
feat: Implement campaign zip export and import

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -53,7 +53,7 @@
                     <button id="save-campaign-button">Save Campaign</button>
                     <div style="margin-top: 10px;">
                         <label for="load-campaign-input" class="button-like-label">Load Campaign</label>
-                        <input type="file" id="load-campaign-input" accept=".json" style="display: none;">
+                        <input type="file" id="load-campaign-input" accept=".zip,.json" style="display: none;">
                     </div>
                 </div>
             </div>
@@ -117,6 +117,7 @@
     <div id="hover-label" class="hover-label" style="display: none;"></div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.10.377/pdf.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="dm_view.js"></script>
     <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 


### PR DESCRIPTION
This commit introduces a comprehensive save and load system for the DnDemicube campaign tool.

The 'Save Campaign' functionality has been overhauled to generate a complete `.zip` archive. This archive packages all necessary campaign assets into a single file, including:
- A `campaign.json` file containing all notes, character data, map definitions, and active view state.
- An `images/` directory containing all uploaded map images.
- A `characters/` directory containing all uploaded character sheet PDFs.

The 'Load Campaign' functionality has been updated to accept these `.zip` archives. Upon loading, the application now fully restores the campaign state by:
- Unzipping the archive in the browser.
- Parsing the `campaign.json` file.
- Re-creating object URLs for all map images and character PDFs from the data in the zip file.
- Repopulating all UI lists and refreshing the canvas.

To support this, the internal data structure for characters was enhanced to store PDF data persistently. The system also maintains backward compatibility for loading old `.json` campaign files.