### PR TITLE
fix(character): Make Attacks, Features, and Equipment fields usable

### DIFF
--- a/Projects/DnDemicube/character_sheet.html
+++ b/Projects/DnDemicube/character_sheet.html
@@ -156,19 +156,17 @@
 
         <section class="attacks-spellcasting">
             <h3>Attacks & Spellcasting</h3>
-            <div id="weapon-attacks"></div>
-            <div id="cantrips"></div>
-            <div id="spells"></div>
+            <textarea name="attacks_and_spellcasting" rows="10" style="width: 95%;"></textarea>
         </section>
 
         <section class="features-traits">
             <h3>Features & Traits</h3>
-            <div id="features-traits-list"></div>
+            <textarea name="features_and_traits" rows="10" style="width: 95%;"></textarea>
         </section>
 
         <section class="equipment">
             <h3>Equipment</h3>
-            <div id="equipment-list"></div>
+            <textarea name="equipment" rows="10" style="width: 95%;"></textarea>
         </section>
 
         <section class="character-appearance">


### PR DESCRIPTION
This commit fixes a bug where the 'Attacks & Spellcasting', 'Features & Traits', and 'Equipment' fields on your character sheet were unusable.

The issue was that these sections were implemented as `div` elements, which were not compatible with the JavaScript functions for loading and saving character data.

The fix replaces these `div` elements with `<textarea>` elements, making them fully functional and allowing them to be populated from JSON data and saved correctly.