### PR TITLE
Feat: Unify map management and add Edit/View toggle

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -526,3 +526,72 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     text-decoration: none;
     cursor: pointer;
 }
+
+/* Mode Toggle Switch */
+.mode-toggle-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #5f6a7a; /* Darker grey for off state */
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #3a4f6a; /* Use the selected item color */
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #3a4f6a;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -22,16 +22,25 @@
                     <label for="upload-maps-input">Upload Map Files:</label>
                     <input type="file" id="upload-maps-input" accept="image/*" multiple>
                 </div>
-                <ul id="uploaded-maps-list" style="list-style-type: none; padding-left: 0; margin-top: 10px; overflow-y: auto; max-height: 150px;">
-                    <!-- Uploaded map files will be listed here -->
+                <ul id="maps-list" style="list-style-type: none; padding-left: 0; margin-top: 10px; overflow-y: auto; max-height: 150px;">
+                    <!-- Map files will be listed here -->
                 </ul>
+            </div>
+
+            <div class="sidebar-section">
+                <div class="mode-toggle-container" style="display: flex; align-items: center; justify-content: center; gap: 10px;">
+                    <span class="mode-label">Edit</span>
+                    <label class="switch">
+                        <input type="checkbox" id="mode-toggle-switch" disabled>
+                        <span class="slider round"></span>
+                    </label>
+                    <span class="mode-label">View</span>
+                </div>
             </div>
 
             <div class="sidebar-section" id="map-tools-section">
                 <h3>Map Tools</h3>
                 <div class="map-tools-buttons">
-                    <button id="btn-add-to-active" disabled>Add to Active List</button>
-                    <button id="btn-remove-from-active" disabled>Remove from Active List</button>
                     <button id="btn-link-child-map" disabled>Link to Child Map</button>
                     <button id="btn-link-note" disabled>Link Note</button>
                     <button id="btn-link-character" disabled>Link Character</button>
@@ -40,12 +49,6 @@
                 </div>
             </div>
 
-            <div class="sidebar-section" id="active-maps-section" style="overflow-y: auto; overflow-x: auto; max-height: 200px;">
-                <h3>Active View</h3>
-                <ul id="active-maps-list" style="white-space: nowrap;">
-                    <!-- Active map and its layers/sub-maps will be listed here -->
-                </ul>
-            </div>
 
             <div class="sidebar-section">
                 <h3>Campaign</h3>


### PR DESCRIPTION
This commit refactors the map management UI and logic in the DM view to streamline your experience.

Key changes:
- Merged the "Managed Maps" and "Active View" lists into a single, unified map list.
- Removed the "Add to Active List" and "Remove from Active List" buttons, as all maps are now automatically part of the main list.
- Introduced a global "Edit/View" toggle switch that controls the interaction mode for the currently selected map.
- "Edit" mode allows for creating and modifying map links and overlays.
- "View" mode is for presentation, allowing navigation through map links and controlling player view visibility.
- Updated the save/load functionality to support the new data structure while maintaining backward compatibility with older campaign save files. Old saves are automatically converted to the new format upon loading.