### PR TITLE
Fix: Child maps now correctly inherit 'Active' mode

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -630,6 +630,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const childMapName = overlay.linkedMapName;
                     const childMapData = detailedMapData.get(childMapName);
                     if (childMapData) {
+                        childMapData.mode = 'view'; // Ensure child map is in view mode when navigated to this way
                         selectedMapFileName = childMapName;
                         clearAllSelections();
                         const mapItems = mapsList.querySelectorAll('li');


### PR DESCRIPTION
This commit addresses a bug where navigating to a child map via a polygon link would cause the child map to open in 'Edit' mode, even if the global toggle was set to 'Active'.

The fix ensures that when you click a polygon link in 'Active' mode, the destination child map's mode is explicitly set to 'view' ('Active'). This provides a seamless user experience when navigating between linked maps in 'Active' mode.