### PR TITLE
Fix character icon visibility and profile photo display

### DIFF
--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -200,6 +200,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 sheetData[`${attr}_modifier`] = modifiers[attr].textContent;
             }
 
+            if (portraitPreview.style.display !== 'none') {
+                sheetData['character_portrait'] = portraitPreview.src;
+            }
+
             window.parent.postMessage({ type: 'sheetDataForView', data: sheetData }, '*');
         }
     });

--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -613,3 +613,13 @@ input:checked + .slider:before {
 .button-like-a:hover {
     background-color: #a0b4c9;
 }
+
+#character-preview-body img {
+    max-width: 150px;
+    max-height: 150px;
+    object-fit: cover;
+    border-radius: 5px;
+    float: left;
+    margin-right: 15px;
+    margin-bottom: 10px;
+}

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1779,9 +1779,21 @@ document.addEventListener('DOMContentLoaded', () => {
                         const reader = new FileReader();
                         reader.onloadend = () => {
                             const base64dataUrl = reader.result;
-                            const visibleOverlays = mapData.overlays.filter(overlay => {
-                                return typeof overlay.playerVisible === 'boolean' ? overlay.playerVisible : true;
-                            });
+                            const visibleOverlays = mapData.overlays
+                                .filter(overlay => (typeof overlay.playerVisible === 'boolean' ? overlay.playerVisible : true))
+                                .map(overlay => {
+                                    if (overlay.type === 'characterLink' && overlay.linkedCharacterId) {
+                                        const character = charactersData.find(c => c.id === overlay.linkedCharacterId);
+                                        if (character && character.sheetData && character.sheetData.character_portrait) {
+                                            return {
+                                                ...overlay,
+                                                character_portrait: character.sheetData.character_portrait
+                                            };
+                                        }
+                                    }
+                                    return overlay;
+                                });
+
                             playerWindow.postMessage({
                                 type: 'loadMap',
                                 mapDataUrl: base64dataUrl,

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -115,6 +115,39 @@ function drawOverlays_PlayerView(overlays) {
             pCtx.textAlign = 'center';
             pCtx.textBaseline = 'middle';
             pCtx.fillText('📝', canvasX, canvasY);
+        } else if (overlay.type === 'characterLink' && overlay.position) {
+            const iconSize = 20; // The size of the icon on the canvas
+            const canvasX = (overlay.position.x * currentMapDisplayData.ratio) + currentMapDisplayData.offsetX;
+            const canvasY = (overlay.position.y * currentMapDisplayData.ratio) + currentMapDisplayData.offsetY;
+
+            let fillStyle = 'rgba(102, 255, 102, 0.9)'; // Greenish if visible to player
+
+            pCtx.fillStyle = fillStyle;
+            pCtx.fillRect(canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
+            pCtx.strokeStyle = 'black';
+            pCtx.strokeRect(canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
+
+            pCtx.fillStyle = 'black';
+            pCtx.font = `${iconSize * 0.8}px sans-serif`;
+            pCtx.textAlign = 'center';
+            pCtx.textBaseline = 'middle';
+            pCtx.fillText('👤', canvasX, canvasY);
+
+            if (overlay.character_portrait) {
+                const img = new Image();
+                img.onload = function() {
+                    pCtx.save();
+                    pCtx.beginPath();
+                    pCtx.arc(canvasX, canvasY, iconSize / 2, 0, Math.PI * 2, true);
+                    pCtx.closePath();
+                    pCtx.clip();
+
+                    pCtx.drawImage(img, canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
+
+                    pCtx.restore();
+                };
+                img.src = overlay.character_portrait;
+            }
         }
     });
 }


### PR DESCRIPTION
This commit addresses three issues related to character display in the DnDemicube project.

1.  **Character icon visibility in player view:** Character icons were not appearing in the player view even when toggled on. This was because the player view's rendering logic was missing the case for `characterLink` overlays. This has been fixed by adding the necessary drawing logic to `player_view.js` and enriching the overlay data with the character portrait URL in `dm_view.js`.

2.  **Missing character profile photo in character tab:** The character profile photo was not displaying in the 'View Character' popup on the character tab. This was because `character_sheet.js` was not including the portrait URL in the data it sent back. This has been fixed.

3.  **Standardized character profile image size:** The character profile images were not a standard size. A CSS rule has been added to `dm_view.css` to standardize the size of the profile images in the preview overlay.