### PR TITLE
Fixes for DnDemicube campaign load and UI

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -444,6 +444,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const characterPreviewOverlay = document.getElementById('character-preview-overlay');
             if (characterPreviewOverlay) {
                 characterPreviewOverlay.style.display = 'none';
+                if (playerWindow && !playerWindow.closed) {
+                    playerWindow.postMessage({ type: 'hideCharacterPreview' }, '*');
+                }
             }
         });
     }
@@ -623,7 +626,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const newOverlay = {
                 type: 'noteLink',
                 position: imageCoords,
-                linkedNoteId: null
+                linkedNoteId: null,
+                playerVisible: false
             };
             selectedMapData.overlays.push(newOverlay);
             console.log('Note icon placed. Overlay:', newOverlay);
@@ -635,7 +639,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const newOverlay = {
                 type: 'characterLink',
                 position: imageCoords,
-                linkedCharacterId: null
+                linkedCharacterId: null,
+                playerVisible: false
             };
             selectedMapData.overlays.push(newOverlay);
             console.log('Character icon placed. Overlay:', newOverlay);
@@ -1361,7 +1366,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const newOverlay = {
                             type: 'childMapLink',
                             polygon: [...currentPolygonPoints],
-                            linkedMapName: clickedFileName
+                            linkedMapName: clickedFileName,
+                            playerVisible: false
                         };
                         parentMapData.overlays.push(newOverlay);
                         alert(`Map "${clickedFileName}" successfully linked as a new child to "${parentMapData.name}".`);
@@ -1680,10 +1686,16 @@ document.addEventListener('DOMContentLoaded', () => {
             if (imageFile) {
                 const promise = imageFile.async("blob").then(blob => {
                     const url = URL.createObjectURL(blob);
+                    const overlays = definition.overlays || [];
+                    overlays.forEach(overlay => {
+                        if (typeof overlay.playerVisible === 'undefined') {
+                            overlay.playerVisible = true;
+                        }
+                    });
                     detailedMapData.set(mapName, {
                         name: definition.name,
                         url: url,
-                        overlays: definition.overlays || [],
+                        overlays: overlays,
                         mode: definition.mode || 'edit' // Backward compatibility
                     });
                     displayedFileNames.add(mapName);

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -30,6 +30,15 @@
             position: relative;
             color: #e0e0e0;
         }
+        #character-preview-body img {
+            max-width: 150px;
+            max-height: 150px;
+            object-fit: cover;
+            border-radius: 5px;
+            float: left;
+            margin-right: 15px;
+            margin-bottom: 10px;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
This commit addresses three issues in the DnDemicube project:

1.  **Link Visibility:**
    - Newly created links on maps now default to being hidden from the player view (`playerVisible: false`).
    - When loading a campaign from an older save file where the `playerVisible` property is not present, it now defaults to `true` to ensure backward compatibility.

2.  **Character Overlay Sync:**
    - The character details overlay now synchronizes its closing between the DM and player views. When the DM closes the overlay, it will also close for the player.

3.  **UI Consistency:**
    - The character portrait image in the character details overlay is now the same size for both the DM and player views (max 150x150px).