### PR TITLE
Fix: Persist 'Show details to players' checkbox state

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2762,7 +2762,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (characterNameInput) characterNameInput.value = character.name;
 
         if (characterSheetIframe && characterSheetIframe.contentWindow) {
-            characterSheetIframe.contentWindow.postMessage({ type: 'loadCharacterSheet', data: character.sheetData || {} }, '*');
+            const dataToSend = {
+                ...(character.sheetData || {}),
+                isDetailsVisible: character.isDetailsVisible
+            };
+            characterSheetIframe.contentWindow.postMessage({ type: 'loadCharacterSheet', data: dataToSend }, '*');
         } else {
             // This case should not happen if the iframe is loaded, but as a fallback:
             console.warn("Character sheet iframe not ready to receive data.");
@@ -3356,6 +3360,13 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (event.data.type === 'characterSheetReady') {
             if (selectedCharacterId) {
                 loadCharacterIntoEditor(selectedCharacterId);
+            }
+        } else if (event.data.type === 'characterDetailsVisibilityChange') {
+            if (selectedCharacterId) {
+                const character = charactersData.find(c => c.id === selectedCharacterId);
+                if (character) {
+                    character.isDetailsVisible = event.data.isDetailsVisible;
+                }
             }
         } else if (event.data.type === 'sheetDataForView') {
             const character = charactersData.find(c => c.id === selectedCharacterId);


### PR DESCRIPTION
- I updated the `dm_view.js` file to correctly save the `isDetailsVisible` state of a character when the 'Save Character' button is clicked.
- I updated the `loadCharacterIntoEditor` function to correctly set the checkbox state when a character is loaded.