### PR TITLE
Fix: Resolve ReferenceError and improve context menu logic

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -655,7 +655,6 @@ document.addEventListener('DOMContentLoaded', () => {
                             }
                         });
                         displayMapOnCanvas(childMapName);
-                        updateButtonStates();
                         sendMapToPlayerView(childMapName);
                         console.log(`Switched to child map: ${childMapName}`);
                     } else {
@@ -1774,39 +1773,40 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!imageCoords) return;
 
         const selectedMapData = detailedMapData.get(selectedMapFileName);
-        if (!selectedMapData || !selectedMapData.overlays) return;
+        if (!selectedMapData) return;
 
-        for (let i = selectedMapData.overlays.length - 1; i >= 0; i--) {
-            const overlay = selectedMapData.overlays[i];
-            if (overlay.type === 'childMapLink' && overlay.polygon && isPointInPolygon(imageCoords, overlay.polygon)) {
-                selectedPolygonForContextMenu = {
-                    overlay: overlay,
-                    index: i,
-                    parentMapName: selectedMapData.name,
-                    source: selectedMapData.mode
-                };
+        // Check for overlay interaction first
+        if (selectedMapData.overlays) {
+            for (let i = selectedMapData.overlays.length - 1; i >= 0; i--) {
+                const overlay = selectedMapData.overlays[i];
+                if (overlay.type === 'childMapLink' && overlay.polygon && isPointInPolygon(imageCoords, overlay.polygon)) {
+                    selectedPolygonForContextMenu = {
+                        overlay: overlay,
+                        index: i,
+                        parentMapName: selectedMapData.name,
+                        source: selectedMapData.mode
+                    };
 
-                const toggleVisibilityItem = polygonContextMenu.querySelector('[data-action="toggle-player-visibility"]');
-                const changeChildMapItem = polygonContextMenu.querySelector('[data-action="change-child-map"]');
-                const redrawPolygonItem = polygonContextMenu.querySelector('[data-action="redraw-polygon"]');
-                const movePolygonItem = polygonContextMenu.querySelector('[data-action="move-polygon"]');
-                const deleteLinkItem = polygonContextMenu.querySelector('[data-action="delete-link"]');
+                    const toggleVisibilityItem = polygonContextMenu.querySelector('[data-action="toggle-player-visibility"]');
+                    const changeChildMapItem = polygonContextMenu.querySelector('[data-action="change-child-map"]');
+                    const redrawPolygonItem = polygonContextMenu.querySelector('[data-action="redraw-polygon"]');
+                    const movePolygonItem = polygonContextMenu.querySelector('[data-action="move-polygon"]');
+                    const deleteLinkItem = polygonContextMenu.querySelector('[data-action="delete-link"]');
 
-                if (selectedMapData.mode === 'view') {
-                    if (toggleVisibilityItem) toggleVisibilityItem.style.display = 'list-item';
-                    if (changeChildMapItem) changeChildMapItem.style.display = 'none';
-                    if (redrawPolygonItem) redrawPolygonItem.style.display = 'none';
-                    if (movePolygonItem) movePolygonItem.style.display = 'none';
-                    if (deleteLinkItem) deleteLinkItem.style.display = 'none';
-                } else { // edit mode
-                    if (toggleVisibilityItem) toggleVisibilityItem.style.display = 'none';
-                    if (changeChildMapItem) changeChildMapItem.style.display = 'list-item';
-                    if (redrawPolygonItem) redrawPolygonItem.style.display = 'list-item';
-                    if (movePolygonItem) movePolygonItem.style.display = 'list-item';
-                    if (deleteLinkItem) deleteLinkItem.style.display = 'list-item';
-                }
+                    if (selectedMapData.mode === 'view') {
+                        if (toggleVisibilityItem) toggleVisibilityItem.style.display = 'list-item';
+                        if (changeChildMapItem) changeChildMapItem.style.display = 'none';
+                        if (redrawPolygonItem) redrawPolygonItem.style.display = 'none';
+                        if (movePolygonItem) movePolygonItem.style.display = 'none';
+                        if (deleteLinkItem) deleteLinkItem.style.display = 'none';
+                    } else { // edit mode
+                        if (toggleVisibilityItem) toggleVisibilityItem.style.display = 'none';
+                        if (changeChildMapItem) changeChildMapItem.style.display = 'list-item';
+                        if (redrawPolygonItem) redrawPolygonItem.style.display = 'list-item';
+                        if (movePolygonItem) movePolygonItem.style.display = 'list-item';
+                        if (deleteLinkItem) deleteLinkItem.style.display = 'list-item';
+                    }
 
-                    // Use pageX/pageY for positioning relative to the entire document
                     polygonContextMenu.style.left = `${event.pageX}px`;
                     polygonContextMenu.style.top = `${event.pageY}px`;
                     polygonContextMenu.style.display = 'block';
@@ -1874,6 +1874,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     return;
                 }
             }
+        }
+
+        // If no overlay was hit, show the general map tools menu, but only in edit mode.
+        if (selectedMapData.mode === 'edit') {
+            mapToolsContextMenu.style.left = `${event.pageX}px`;
+            mapToolsContextMenu.style.top = `${event.pageY}px`;
+            mapToolsContextMenu.style.display = 'block';
+        }
     });
 
     // Global click listener to hide context menu


### PR DESCRIPTION
This commit addresses a `ReferenceError: updateButtonStates is not defined` that occurred after refactoring the map tools from a sidebar to a right-click context menu.

The following changes were made:
- Removed the obsolete call to `updateButtonStates()` in `dm_view.js`, which was causing the primary error.
- Corrected the context menu logic to ensure the general map tools menu appears when right-clicking on the canvas in 'edit' mode, which was a bug in the new implementation.
- Verified that the changes do not impact the recently added save and upload campaign functionality.