### PR TITLE
I've fixed the 'Redraw Polygon' functionality.

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2048,6 +2048,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         currentPolygonPoints = [];
                         polygonDrawingComplete = false;
                         parentMapData.overlays.splice(index, 1);
+                        drawingCanvas.style.pointerEvents = 'auto';
                         dmCanvas.style.cursor = 'crosshair';
                         alert(`Redrawing polygon for link to "${preservedLinkedMapNameForRedraw}". Click on the map to start drawing. Click the first point to close it.`);
                         if (selectedMapFileName === parentMapName) {


### PR DESCRIPTION
The 'Redraw Polygon' feature was broken after the introduction of a dedicated drawing canvas. The drawing canvas was not listening for pointer events during a redraw operation, which made it impossible to draw a new polygon.

This change fixes the issue by enabling pointer events on the drawing canvas when the 'redraw-polygon' action is triggered from the context menu.