### PR TITLE
feat: Enhance Dice Roller and Mirror to Player View

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -673,7 +673,7 @@ input:checked + .slider:before {
 }
 
 .overlay-content {
-    background-color: #2a3138;
+    background-color: rgba(42, 49, 56, 0.85); /* Semi-transparent background */
     padding: 20px;
     border: 1px solid #3f4c5a;
     width: 80%;
@@ -681,6 +681,11 @@ input:checked + .slider:before {
     border-radius: 5px;
     position: relative;
     color: #e0e0e0;
+    text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.7); /* Shadow for all text */
+}
+
+.overlay-content h2 {
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5); /* More pronounced shadow for the title */
 }
 
 .dice-roller-content {

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -94,7 +94,7 @@
         <canvas id="dm-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
         <div id="dice-roller-icon" class="floating-icon">
-            <img src="https://raw.githubusercontent.com/demicube/dndemicube-d20-icon/main/d20-icon-white.svg" alt="d20 icon" style="width: 100%; height: 100%;">
+            <img src="assets/d20icon.png" alt="d20 icon" style="width: 100%; height: 100%;">
         </div>
     </div>
     <div id="note-editor-container" style="display: none; flex-grow: 1; padding: 10px;"><div id="note-editor-area" style="display: flex; flex-direction: column; height: 100%;">
@@ -201,9 +201,28 @@
             <span id="dice-roller-close-button" class="close-button">&times;</span>
             <h2>Dice Roller & Initiative Tracker</h2>
             <div class="dice-roller-content">
-                <div id="dice-roller-placeholder">
-                    <h3>Dice Rolling</h3>
-                    <p>Dice rolling functionality will be implemented here.</p>
+                <div id="dice-roller-content-container">
+                    <div id="dice-tray" style="height: 60px; border-bottom: 1px solid #4a5f7a; margin-bottom: 15px; display: flex; justify-content: center; align-items: center; font-size: 2em;">
+                        <span id="dice-result-sum">0</span>
+                    </div>
+                    <div id="dice-result-details" style="height: 30px; font-size: 0.9em; color: #a0b4c9; text-align: center; margin-bottom: 15px;"></div>
+                    <div id="dice-controls" style="display: flex; flex-direction: column; align-items: center; gap: 15px;">
+                        <button id="roll-button" style="width: 50%;">Roll</button>
+                        <div id="dice-buttons-grid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; width: 100%;">
+                            <button class="dice-button" data-die="d4">d4 <span class="dice-count"></span></button>
+                            <button class="dice-button" data-die="d6">d6 <span class="dice-count"></span></button>
+                            <button class="dice-button" data-die="d8">d8 <span class="dice-count"></span></button>
+                            <button class="dice-button" data-die="d10">d10 <span class="dice-count"></span></button>
+                            <button class="dice-button" data-die="d12">d12 <span class="dice-count"></span></button>
+                            <button class="dice-button" data-die="d20">d20 <span class="dice-count"></span></button>
+                            <button class="dice-button" data-die="d100">d100 <span class="dice-count"></span></button>
+                            <div style="display: flex; align-items: center; gap: 5px;">
+                                <button class="dice-button" data-die="d_custom" style="flex-grow: 1;">d</button>
+                                <input type="number" id="custom-die-input" min="2" max="1000" value="100" style="width: 60px; text-align: center; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0;">
+                                <span class="dice-count" data-die-custom></span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div id="initiative-tracker-placeholder">
                     <h3>Initiative Tracker</h3>

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -124,7 +124,7 @@
     <div id="player-map-container" class="relative">
         <canvas id="player-canvas"></canvas>
         <div id="dice-roller-icon" class="absolute bottom-5 right-5 w-12 h-12 cursor-pointer z-10">
-            <img src="https://raw.githubusercontent.com/demicube/dndemicube-d20-icon/main/d20-icon-white.svg" alt="d20 icon" class="w-full h-full">
+            <img src="assets/d20icon.png" alt="d20 icon" class="w-full h-full">
         </div>
     </div>
     <div id="note-preview-overlay" class="note-preview-overlay" style="display: none;">
@@ -143,13 +143,32 @@
     <script src="player_view.js"></script>
 
     <div id="dice-roller-overlay" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-20" style="display: none;">
-        <div class="bg-gray-800 p-5 rounded-lg max-w-2xl w-full relative text-white">
+        <div class="bg-gray-800/80 p-5 rounded-lg max-w-2xl w-full relative text-white [text-shadow:1px_1px_3px_rgba(0,0,0,0.7)]">
             <span id="dice-roller-close-button" class="absolute top-2 right-3 text-gray-400 text-3xl font-bold cursor-pointer hover:text-white">&times;</span>
-            <h2 class="text-2xl font-bold mb-4">Dice Roller & Initiative Tracker</h2>
+            <h2 class="text-2xl font-bold mb-4 [text-shadow:2px_2px_4px_rgba(0,0,0,0.5)]">Dice Roller & Initiative Tracker</h2>
             <div class="flex justify-between space-x-4">
-                <div id="dice-roller-placeholder" class="w-1/2 border border-gray-600 p-4 rounded">
-                    <h3 class="text-xl font-semibold mb-2">Dice Rolling</h3>
-                    <p>Dice rolling functionality will be implemented here.</p>
+                <div id="dice-roller-content-container" class="w-1/2 border-gray-600 p-4 rounded">
+                    <div id="dice-tray" class="h-16 border-b border-gray-600 mb-4 flex justify-center items-center text-4xl">
+                        <span id="dice-result-sum">0</span>
+                    </div>
+                    <div id="dice-result-details" class="h-8 text-sm text-gray-400 text-center mb-4"></div>
+                    <div id="dice-controls" class="flex flex-col items-center gap-4">
+                        <button id="roll-button" class="w-1/2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">Roll</button>
+                        <div id="dice-buttons-grid" class="grid grid-cols-4 gap-2 w-full">
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d4">d4 <span class="dice-count"></span></button>
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d6">d6 <span class="dice-count"></span></button>
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d8">d8 <span class="dice-count"></span></button>
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d10">d10 <span class="dice-count"></span></button>
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d12">d12 <span class="dice-count"></span></button>
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d20">d20 <span class="dice-count"></span></button>
+                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d100">d100 <span class="dice-count"></span></button>
+                            <div class="flex items-center gap-1">
+                                <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded flex-grow" data-die="d_custom">d</button>
+                                <input type="number" id="custom-die-input" min="2" max="1000" value="100" class="w-16 text-center bg-gray-900 border border-gray-600 text-white rounded">
+                                <span class="dice-count" data-die-custom></span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div id="initiative-tracker-placeholder" class="w-1/2 border border-gray-600 p-4 rounded">
                     <h3 class="text-xl font-semibold mb-2">Initiative Tracker</h3>

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -397,6 +397,19 @@ window.addEventListener('message', (event) => {
                     characterPreviewOverlayToHide.style.display = 'none';
                 }
                 break;
+            case 'diceMenuState':
+                if (diceRollerOverlay) {
+                    diceRollerOverlay.style.display = data.isOpen ? 'flex' : 'none';
+                }
+                break;
+            case 'diceRoll':
+                const diceResultSum = document.getElementById('dice-result-sum');
+                const diceResultDetails = document.getElementById('dice-result-details');
+                if (diceResultSum && diceResultDetails) {
+                    diceResultSum.textContent = data.sum;
+                    diceResultDetails.textContent = `Rolls: [${data.results.join(', ')}]`;
+                }
+                break;
             default:
                 console.log("Player view received unhandled message type:", data.type);
                 break;
@@ -473,31 +486,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Dice Roller Overlay Logic
-    if (diceRollerIcon) {
-        diceRollerIcon.addEventListener('click', () => {
-            if (diceRollerOverlay) {
-                diceRollerOverlay.style.display = 'flex';
-            }
-        });
-    }
-
-    if (diceRollerCloseButton) {
-        diceRollerCloseButton.addEventListener('click', () => {
-            if (diceRollerOverlay) {
-                diceRollerOverlay.style.display = 'none';
-            }
-        });
-    }
-
-    if (diceRollerOverlay) {
-        diceRollerOverlay.addEventListener('click', (event) => {
-            // Close if the click is on the overlay background, but not on its content
-            if (event.target === diceRollerOverlay) {
-                diceRollerOverlay.style.display = 'none';
-            }
-        });
-    }
+    // Dice Roller Overlay Logic is now controlled by the DM
 });
 
 // Fallback if script runs before DOM is fully ready and elements aren't found.


### PR DESCRIPTION
This commit introduces several enhancements to the dice roller feature and ensures synchronization between the DM and Player views.

Key changes:
- Replaced the external d20 icon with a local asset (`assets/d20icon.png`) in both DM and Player views.
- Implemented real-time mirroring of the dice menu. The DM opening or closing the menu now reflects immediately in the player view.
- Restyled the dice menu overlay to be semi-transparent with text shadows for better visibility of the underlying map.
- Completely rebuilt the dice roller UI with a dedicated results tray, a roll button, and a grid of dice buttons (d4, d6, d8, d10, d12, d20, d100, and custom).
- Added interactive logic for selecting dice: left-click to add a die, right-click to remove.
- Implemented the core dice rolling functionality, which calculates the sum and displays individual roll results.
- Ensured that dice roll results from the DM's roller are mirrored to the player's view in real-time.