### PR TITLE
fix: Correct dice menu opening logic

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3567,9 +3567,8 @@ function generateCharacterMarkdown(sheetData, notes, forPlayerView = false, isDe
     if (diceRollerIcon) {
         diceRollerIcon.addEventListener('click', () => {
             if (diceRollerOverlay) {
-                const isOpen = diceRollerOverlay.style.display !== 'flex';
-                diceRollerOverlay.style.display = isOpen ? 'flex' : 'none';
-                sendDiceMenuStateToPlayerView(isOpen);
+                diceRollerOverlay.style.display = 'flex';
+                sendDiceMenuStateToPlayerView(true);
             }
         });
     }


### PR DESCRIPTION
The d20 icon's click event listener was previously implemented as a toggle, which was incorrect. This caused unexpected behavior when you tried to reopen the dice menu using the icon after closing it via other means.

This commit corrects the logic so that clicking the d20 icon now consistently opens the dice menu overlay. The responsibility for closing the menu remains with the close button and clicking on the overlay background.