### PR TITLE
feat: Implement dice dialogue record

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -700,3 +700,28 @@ input:checked + .slider:before {
     padding: 10px;
     border-radius: 4px;
 }
+
+.dice-dialogue {
+    position: absolute;
+    bottom: 80px; /* Position above the d20 icon */
+    right: 20px;
+    width: 300px;
+    max-height: 200px;
+    background-color: rgba(40, 50, 60, 0.9);
+    border-radius: 10px;
+    padding: 10px;
+    display: none; /* Initially hidden */
+    flex-direction: column-reverse;
+    overflow: hidden;
+    border: 1px solid #4a5f7a;
+}
+
+.dice-dialogue-message {
+    background-color: rgba(21, 25, 30, 0.8);
+    color: #e0e0e0;
+    padding: 8px;
+    margin-bottom: 5px;
+    border-radius: 5px;
+    font-size: 0.9em;
+    border-left: 3px solid #76a9d7;
+}

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -93,6 +93,7 @@
     <div id="map-container">
         <canvas id="dm-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
+        <div id="dice-dialogue-record" class="dice-dialogue"></div>
         <div id="dice-roller-icon" class="floating-icon">
             <img src="assets/d20icon.png" alt="d20 icon" style="width: 100%; height: 100%;">
         </div>


### PR DESCRIPTION
This commit introduces a new dice dialogue record feature.

- The dice roll result format has been changed to show the die type and the rolls for each type, e.g., `Custom: d8[3], d12[4,10]`.
- A floating dice dialogue has been added that appears when a new roll is made.
- The dialogue displays the last 5 dice rolls and disappears after 10 seconds.
- The dialogue is styled with the same transparent theme as the dice roller.