### PR TITLE
fix: Add z-index to dice dialogue

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -714,6 +714,7 @@ input:checked + .slider:before {
     flex-direction: column-reverse;
     overflow: hidden;
     border: 1px solid #4a5f7a;
+    z-index: 3;
 }
 
 .dice-dialogue-message {


### PR DESCRIPTION
This commit fixes a bug where the dice dialogue was not appearing. The dialogue was being rendered behind the map canvas because it was missing a `z-index` property. This commit adds a `z-index` of 3 to the `.dice-dialogue` class to ensure it is displayed on top of the other elements.