### PR TITLE
I've implemented the Dice Menu and Persistent Roll History features f…

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -726,3 +726,51 @@ input:checked + .slider:before {
     font-size: 0.9em;
     border-left: 3px solid #76a9d7;
 }
+
+/* Dice Icon Menu */
+.dice-icon-menu {
+    position: absolute;
+    bottom: 80px; /* Position above the d20 icon */
+    right: 20px;
+    background-color: #2a3138;
+    border: 1px solid #3f4c5a;
+    border-radius: 5px;
+    z-index: 1001;
+    width: 200px;
+}
+
+.dice-menu-item {
+    padding: 10px 15px;
+    cursor: pointer;
+    color: #e0e0e0;
+}
+
+.dice-menu-item:hover {
+    background-color: #3f4c5a;
+    color: #b6cae1;
+}
+
+/* Persistent Action Log */
+.dice-dialogue.persistent-log {
+    position: fixed;
+    bottom: 20px;
+    right: 80px;
+    width: 350px;
+    height: 400px;
+    max-height: 80vh;
+    flex-direction: column;
+    overflow-y: auto;
+    /* The rest of the styling is inherited from .dice-dialogue */
+}
+
+#action-log-minimize-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: none;
+    border: none;
+    color: #e0e0e0;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 0 5px;
+}

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -97,6 +97,11 @@
         <div id="dice-roller-icon" class="floating-icon">
             <img src="assets/d20icon.png" alt="d20 icon" style="width: 100%; height: 100%;">
         </div>
+        <div id="dice-icon-menu" class="dice-icon-menu" style="display: none;">
+            <div class="dice-menu-item" data-action="open-dice-roller">Dice Roller</div>
+            <div class="dice-menu-item" data-action="open-initiative-tracker">Initiative Tracker</div>
+            <div class="dice-menu-item" data-action="open-action-log">Action Log</div>
+        </div>
     </div>
     <div id="note-editor-container" style="display: none; flex-grow: 1; padding: 10px;"><div id="note-editor-area" style="display: flex; flex-direction: column; height: 100%;">
             <input type="text" id="note-title-input" placeholder="Note Title" />


### PR DESCRIPTION
…or you. Here is a summary of the changes:

1.  **Persistent Dice Roll History:**
    - The dice roll history is now saved as part of the campaign data.
    - When you load a campaign, the roll history is restored.
    - The dice log is no longer limited to 5 entries.

2.  **Dice Icon Menu:**
    - The d20 dice icon now opens a menu with three options: 'Dice Roller', 'Initiative Tracker', and 'Action Log'.
    - 'Dice Roller' opens the dice roller overlay.
    - 'Action Log' opens a persistent, scrollable view of the dice roll history.
    - 'Initiative Tracker' is a placeholder for future implementation.