### PR TITLE
feat: Redesign dice roll messages as cards

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -720,7 +720,7 @@ input:checked + .slider:before {
 .dice-dialogue-message {
     background-color: rgba(21, 25, 30, 0.8);
     color: #e0e0e0;
-    padding: 8px;
+    padding: 0;
     margin-bottom: 5px;
     border-radius: 5px;
     font-size: 0.9em;
@@ -773,4 +773,48 @@ input:checked + .slider:before {
     font-size: 20px;
     cursor: pointer;
     padding: 0 5px;
+}
+
+/* Dice Roll Card */
+.dice-roll-card-content {
+    display: flex;
+    gap: 12px;
+    padding: 16px;
+}
+
+.dice-roll-profile-pic {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #4a5f7a;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: bold;
+    color: #e0e0e0;
+    flex-shrink: 0;
+}
+
+.dice-roll-text-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.dice-roll-name {
+    font-size: 16px;
+    line-height: 1.25;
+    margin: 0;
+}
+
+.dice-roll-name strong {
+    font-weight: bold;
+}
+
+.dice-roll-details {
+    font-size: 16px;
+    line-height: 1.5;
+    margin: 0;
+    color: #a0b4c9;
 }


### PR DESCRIPTION
This commit refactors the display of dice roll messages in the action log, changing them from simple text strings to structured cards.

Each card now includes:
- A placeholder for a profile picture (currently defaults to "DM").
- The character name ("Dice Roller") and player name ("DM").
- The detailed breakdown of the dice roll.

This change improves the readability and visual appeal of the action log and prepares the system for future enhancements where characters can make their own rolls.