### PR TITLE
fix: Display roll sum on dice cards

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -818,3 +818,9 @@ input:checked + .slider:before {
     margin: 0;
     color: #a0b4c9;
 }
+
+.dice-roll-sum-text {
+    font-size: 1.2em;
+    font-weight: bold;
+    color: #e0e0e0; /* Make it stand out more than the rest of the details */
+}

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3528,7 +3528,7 @@ function generateCharacterMarkdown(sheetData, notes, forPlayerView = false, isDe
 
         const detailsPara = document.createElement('p');
         detailsPara.classList.add('dice-roll-details');
-        detailsPara.textContent = rollData.roll;
+        detailsPara.innerHTML = `<strong class="dice-roll-sum-text">${rollData.sum}</strong> | ${rollData.roll}`;
         textContainer.appendChild(detailsPara);
 
         return messageElement;


### PR DESCRIPTION
This commit corrects the format of the dice roll cards to include the total sum of the roll. The sum is now displayed in a large, bold font before the detailed roll breakdown, as you requested.