### PR TITLE
feat: Redesign dice roller and add saved rolls

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -203,18 +203,19 @@
     </div>
 
     <div id="dice-roller-overlay" class="overlay" style="display: none;">
-        <div class="overlay-content">
+        <div class="overlay-content" style="display: flex; flex-direction: column; max-width: 800px; width: 90%;">
             <span id="dice-roller-close-button" class="close-button">&times;</span>
-            <h2>Dice Roller & Initiative Tracker</h2>
-            <div class="dice-roller-content">
-                <div id="dice-roller-content-container">
+            <h2>Dice Roller</h2>
+            <div class="dice-roller-content" style="display: flex; flex-grow: 1; gap: 20px;">
+                <!-- Left Column: Dice Rolling -->
+                <div id="dice-roller-main-container" style="flex: 1; display: flex; flex-direction: column;">
                     <div id="dice-tray" style="height: 60px; border-bottom: 1px solid #4a5f7a; margin-bottom: 15px; display: flex; justify-content: center; align-items: center; font-size: 2em;">
                         <span id="dice-result-sum">0</span>
                     </div>
                     <div id="dice-result-details" style="height: 30px; font-size: 0.9em; color: #a0b4c9; text-align: center; margin-bottom: 15px;"></div>
                     <div id="dice-controls" style="display: flex; flex-direction: column; align-items: center; gap: 15px;">
-                        <button id="roll-button" style="width: 50%;">Roll</button>
-                        <div id="dice-buttons-grid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; width: 100%;">
+                        <button id="roll-button" style="width: 80%;">Roll</button>
+                        <div id="dice-buttons-grid" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; width: 100%;">
                             <button class="dice-button" data-die="d4">d4 <span class="dice-count"></span></button>
                             <button class="dice-button" data-die="d6">d6 <span class="dice-count"></span></button>
                             <button class="dice-button" data-die="d8">d8 <span class="dice-count"></span></button>
@@ -230,9 +231,21 @@
                         </div>
                     </div>
                 </div>
-                <div id="initiative-tracker-placeholder">
-                    <h3>Initiative Tracker</h3>
-                    <p>Initiative tracking functionality will be implemented here.</p>
+
+                <!-- Right Column: Saved Rolls -->
+                <div id="saved-rolls-container" style="flex: 1; border-left: 1px solid #4a5f7a; padding-left: 20px; display: flex; flex-direction: column;">
+                    <h3>Save Roll</h3>
+                    <div id="save-roll-form" style="display: flex; gap: 10px; margin-bottom: 20px;">
+                        <input type="text" id="save-roll-name-input" placeholder="Roll Name (e.g. Crossbow)" style="flex-grow: 1; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0; padding: 5px;">
+                        <button id="save-roll-button">Save</button>
+                    </div>
+
+                    <h3>Saved Rolls</h3>
+                    <div id="saved-rolls-list-container" style="flex-grow: 1; overflow-y: auto; background-color: #15191e; border: 1px solid #3f4c5a; padding: 10px;">
+                        <ul id="saved-rolls-list" style="list-style: none; padding: 0; margin: 0;">
+                            <!-- Saved rolls will be populated here by JavaScript -->
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -143,37 +143,15 @@
     <script src="player_view.js"></script>
 
     <div id="dice-roller-overlay" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-20" style="display: none;">
-        <div class="bg-gray-800/80 p-5 rounded-lg max-w-2xl w-full relative text-white [text-shadow:1px_1px_3px_rgba(0,0,0,0.7)]">
+        <div class="bg-gray-800/80 p-5 rounded-lg max-w-md w-full relative text-white [text-shadow:1px_1px_3px_rgba(0,0,0,0.7)]">
             <span id="dice-roller-close-button" class="absolute top-2 right-3 text-gray-400 text-3xl font-bold cursor-pointer hover:text-white">&times;</span>
-            <h2 class="text-2xl font-bold mb-4 [text-shadow:2px_2px_4px_rgba(0,0,0,0.5)]">Dice Roller & Initiative Tracker</h2>
-            <div class="flex justify-between space-x-4">
-                <div id="dice-roller-content-container" class="w-1/2 border-gray-600 p-4 rounded">
-                    <div id="dice-tray" class="h-16 border-b border-gray-600 mb-4 flex justify-center items-center text-4xl">
-                        <span id="dice-result-sum">0</span>
-                    </div>
-                    <div id="dice-result-details" class="h-8 text-sm text-gray-400 text-center mb-4"></div>
-                    <div id="dice-controls" class="flex flex-col items-center gap-4">
-                        <button id="roll-button" class="w-1/2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">Roll</button>
-                        <div id="dice-buttons-grid" class="grid grid-cols-4 gap-2 w-full">
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d4">d4 <span class="dice-count"></span></button>
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d6">d6 <span class="dice-count"></span></button>
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d8">d8 <span class="dice-count"></span></button>
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d10">d10 <span class="dice-count"></span></button>
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d12">d12 <span class="dice-count"></span></button>
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d20">d20 <span class="dice-count"></span></button>
-                            <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded" data-die="d100">d100 <span class="dice-count"></span></button>
-                            <div class="flex items-center gap-1">
-                                <button class="dice-button bg-gray-700 hover:bg-gray-600 p-2 rounded flex-grow" data-die="d_custom">d</button>
-                                <input type="number" id="custom-die-input" min="2" max="1000" value="100" class="w-16 text-center bg-gray-900 border border-gray-600 text-white rounded">
-                                <span class="dice-count" data-die-custom></span>
-                            </div>
-                        </div>
-                    </div>
+            <h2 class="text-2xl font-bold mb-4 [text-shadow:2px_2px_4px_rgba(0,0,0,0.5)]">Dice Roller</h2>
+            <div id="dice-roller-content-container" class="w-full p-4 rounded">
+                <div id="dice-tray" class="h-16 border-b border-gray-600 mb-4 flex justify-center items-center text-4xl">
+                    <span id="dice-result-sum">0</span>
                 </div>
-                <div id="initiative-tracker-placeholder" class="w-1/2 border border-gray-600 p-4 rounded">
-                    <h3 class="text-xl font-semibold mb-2">Initiative Tracker</h3>
-                    <p>Initiative tracking functionality will be implemented here.</p>
-                </div>
+                <div id="dice-result-details" class="h-8 text-sm text-gray-400 text-center mb-4"></div>
+                <!-- The dice controls are not interactable in player view, so they are omitted -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit redesigns the dice roller overlay and introduces a new 'saved rolls' feature.

Key changes:
- The dice roller overlay UI has been updated to a two-column layout.
- The initiative tracker section has been removed.
- A new feature allows users to name and save a combination of dice.
- A 'Saved Rolls' tab has been added to view and roll saved dice combinations.
- When a saved roll is used, its name is sent to the dice roll record.
- Campaign saving and loading have been updated to be backward-compatible while including the new saved rolls data.