### PR TITLE
This commit introduces several improvements to the initiative tracker.

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -90,7 +90,7 @@
             </div>
         </div>
     </div>
-    <div id="initiative-roll-modal" class="modal" style="display: none;">
+    <div id="initiative-roll-modal" class="modal" style="display: none; z-index: 1002;">
         <div class="modal-content">
             <h3>Roll for Initiative</h3>
             <p>How would you like to set the initiative order?</p>


### PR DESCRIPTION
- The initiative roll modal (`roll automatically` or `manually`) now correctly appears in front of the main initiative tracker overlay by fixing a z-index issue.
- The "Initiative Started" message in the action log is now displayed as a single, formatted card and includes the encounter name if a saved initiative is loaded. This prevents the previous issue of multiple unformatted messages being logged.
- When initiative is rolled (either automatically or manually), a new initiative roll card is now logged for each character. This card displays a breakdown of the roll, showing the d20 result, the character's initiative bonus, and the total, providing more clarity to the DM.