### PR TITLE
fix: Restore dice roll messages in activity log

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3548,9 +3548,6 @@ function generateCharacterMarkdown(sheetData, notes, forPlayerView = false, isDe
         if (!diceDialogueRecord) return;
 
         const historyMessage = `${rollData.sum}: ${rollData.roll}`;
-        if (isInitiativeActive) {
-            historyMessage = `(Initiative) ${historyMessage}`;
-        }
         diceRollHistory.push(historyMessage);
 
         const messageElement = createDiceRollCard(rollData);


### PR DESCRIPTION
This commit fixes a regression where dice rolls were no longer appearing in the activity log.

The `showDiceDialogue` function contained a check for the `isInitiativeActive` variable, which was removed in a previous commit. This caused a `ReferenceError` and prevented the function from executing correctly.

This commit removes the erroneous `if` block, restoring the intended functionality.