### PR TITLE
feat: Add initiative modifier to character sheet

### DIFF
--- a/Projects/DnDemicube/character_sheet.html
+++ b/Projects/DnDemicube/character_sheet.html
@@ -97,6 +97,10 @@
                 <label for="ac">Armor Class</label>
                 <input type="text" id="ac" name="ac">
             </div>
+            <div class="initiative">
+                <label for="initiative">Initiative</label>
+                <input type="text" id="initiative" name="initiative">
+            </div>
             <div class="speed">
                 <label for="speed">Speed</label>
                 <input type="text" id="speed" name="speed">


### PR DESCRIPTION
This change adds an initiative modifier field to the character sheet. The new field is located in the combat-info section, next to Armor Class and Speed.

The initiative modifier will be used by the auto-initiative feature in the DM view to calculate a character's initiative roll.

The implementation is backward-compatible with older save files. If an older save file is loaded, the initiative field will be blank, and the auto-initiative feature will default to a modifier of 0.