### PR TITLE
feat: Make character skills clickable for dice rolls

### DIFF
--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -101,14 +101,26 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function createSkill(skill, attr) {
+        const skillId = skill.replace(/\s+/g, '-').toLowerCase();
         const div = document.createElement('div');
         div.innerHTML = `
-            <input type="checkbox" id="skill-${skill.replace(/\s+/g, '-').toLowerCase()}-prof" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_prof">
-            <label for="skill-${skill.replace(/\s+/g, '-').toLowerCase()}-prof">${skill} (${attr.slice(0, 3).toUpperCase()})</label>
-            <input type="text" id="skill-${skill.replace(/\s+/g, '-').toLowerCase()}-mod" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_mod" readonly>
+            <input type="checkbox" id="skill-${skillId}-prof" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_prof">
+            <label for="skill-${skillId}-prof">${skill} (${attr.slice(0, 3).toUpperCase()})</label>
+            <input type="text" id="skill-${skillId}-mod" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_mod" class="clickable" readonly>
         `;
         skillsContainer.appendChild(div);
-        document.getElementById(`skill-${skill.replace(/\s+/g, '-').toLowerCase()}-prof`).addEventListener('change', updateSkills);
+
+        document.getElementById(`skill-${skillId}-prof`).addEventListener('change', updateSkills);
+
+        const modInput = document.getElementById(`skill-${skillId}-mod`);
+        modInput.addEventListener('click', () => {
+            const modifier = modInput.value;
+            window.parent.postMessage({
+                type: 'skillRoll',
+                skillName: skill,
+                modifier: modifier
+            }, '*');
+        });
     }
 
     savingThrowAttrs.forEach(createSavingThrow);

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3263,6 +3263,24 @@ document.addEventListener('DOMContentLoaded', () => {
                     character.isDetailsVisible = event.data.isDetailsVisible;
                 }
             }
+        } else if (event.data.type === 'skillRoll') {
+            const { skillName, modifier } = event.data;
+            const character = charactersData.find(c => c.id === selectedCharacterId);
+            const characterName = character ? character.name : 'Unknown';
+            const playerName = character && character.sheetData ? character.sheetData.player_name : 'DM';
+
+            const d20Roll = Math.floor(Math.random() * 20) + 1;
+            const total = d20Roll + parseInt(modifier);
+
+            const rollData = {
+                characterName: characterName,
+                playerName: playerName,
+                roll: `d20(${d20Roll}) + ${parseInt(modifier)} for ${skillName}`,
+                sum: total
+            };
+
+            showDiceDialogue(rollData);
+            sendDiceRollToPlayerView([d20Roll], total);
         }
     });
 


### PR DESCRIPTION
This commit implements the functionality to make character skills clickable to initiate a dice roll.

- The skill modifier fields on the character sheet are now clickable.
- Clicking a skill modifier triggers a d20 roll plus the skill's modifier.
- The roll result is displayed in the activity log as a dice roll card, showing the character name, skill name, and the detailed roll.