### PR TITLE
feat: Make character skills clickable for dice rolls

### DIFF
--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -103,17 +103,19 @@ document.addEventListener('DOMContentLoaded', function() {
     function createSkill(skill, attr) {
         const skillId = skill.replace(/\s+/g, '-').toLowerCase();
         const div = document.createElement('div');
+        div.classList.add('skill-entry', 'clickable');
         div.innerHTML = `
             <input type="checkbox" id="skill-${skillId}-prof" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_prof">
             <label for="skill-${skillId}-prof">${skill} (${attr.slice(0, 3).toUpperCase()})</label>
-            <input type="text" id="skill-${skillId}-mod" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_mod" class="clickable" readonly>
+            <input type="text" id="skill-${skillId}-mod" name="skill_${skill.replace(/\s+/g, '_').toLowerCase()}_mod" readonly>
         `;
         skillsContainer.appendChild(div);
 
         document.getElementById(`skill-${skillId}-prof`).addEventListener('change', updateSkills);
 
-        const modInput = document.getElementById(`skill-${skillId}-mod`);
-        modInput.addEventListener('click', () => {
+        div.addEventListener('click', (event) => {
+            if (event.target.type === 'checkbox') return;
+            const modInput = document.getElementById(`skill-${skillId}-mod`);
             const modifier = modInput.value;
             window.parent.postMessage({
                 type: 'skillRoll',


### PR DESCRIPTION
This commit implements the functionality to make character skills clickable to initiate a dice roll.

- The entire skill entry on the character sheet is now clickable.
- Clicking a skill triggers a d20 roll plus the skill's modifier.
- The roll result is displayed in the activity log as a dice roll card, showing the character name, skill name, and the detailed roll.
- This replaces a previous implementation where only the modifier input was clickable.