### PR TITLE
feat: Make activity log popup global

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -93,7 +93,6 @@
     <div id="map-container">
         <canvas id="dm-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
-        <div id="dice-dialogue-record" class="dice-dialogue"></div>
         <div id="dice-roller-icon" class="floating-icon">
             <img src="assets/d20icon.png" alt="d20 icon" style="width: 100%; height: 100%;">
         </div>
@@ -304,5 +303,6 @@
             </div>
         </div>
     </div>
+    <div id="dice-dialogue-record" class="dice-dialogue"></div>
 </body>
 </html>


### PR DESCRIPTION
Moves the activity log popup element to be a direct child of the body. This prevents it from being hidden when switching tabs, allowing the popup to be displayed on any tab in the DM view.