### PR TITLE
feat: Add initiative timer and combat log

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -277,6 +277,25 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.initiative-character-hp, .initiative-character-damage {
+    margin-left: 10px;
+    font-size: 0.9em;
+}
+
+.initiative-character-hp input, .initiative-character-damage input {
+    background-color: #15191e;
+    color: #e0e0e0;
+    border: 1px solid #3f4c5a;
+    border-radius: 3px;
+    text-align: center;
+}
+
+#initiative-timers {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 1.1em;
+    color: #b6cae1;
+}
+
 .initiative-character-initials {
     width: 50px;
     height: 50px;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -299,6 +299,10 @@
                 </div>
             </div>
             <div id="initiative-controls" style="margin-top: 20px; display: flex; justify-content: center; align-items: center; gap: 15px;">
+                <div id="initiative-timers" style="display: none; position: absolute; left: 20px; gap: 20px; background-color: #15191e; padding: 5px 10px; border-radius: 5px;">
+                    <span>Real Time: <span id="real-time-timer">00:00:00</span></span>
+                    <span>Game Time: <span id="game-time-timer">0s</span></span>
+                </div>
                 <button id="prev-turn-button" style="display: none;">&lt; Prev</button>
                 <button id="start-initiative-button">Start Initiative</button>
                 <button id="next-turn-button" style="display: none;">Next &gt;</button>


### PR DESCRIPTION
Adds a combat timer and activity log to the initiative tracker.

When the "Start Initiative" button is clicked, it now:
- Displays a real-time and in-game timer. The in-game timer advances by 6 seconds each round.
- Logs a "Combat Started" event.
- Changes to a "Stop Initiative" button.

When the "Stop Initiative" button is clicked, it:
- Stops the timers.
- Logs a "Combat Ended" event with the elapsed time and a survivor status report, including character HP changes and damage dealt.

The combat log is now saved and loaded with the campaign data, with backward compatibility for older save files.