### PR TITLE
feat: Implement initiative tokens on map overlay

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -922,6 +922,28 @@ input:checked + .slider:before {
     box-shadow: 0 0 8px #b6cae1;
 }
 
+#initiative-settings-container .setting-item {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 15px;
+}
+
+#initiative-settings-container label {
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: #a0b4c9;
+}
+
+#initiative-settings-container input[type="range"] {
+    width: 100%;
+}
+
+#initiative-settings-container span {
+    text-align: center;
+    margin-top: 5px;
+    color: #e0e0e0;
+}
+
 .initiative-character-card img {
     width: 35px;
     height: 35px;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -297,6 +297,18 @@
                          <button id="load-initiative-button" style="width: 100%;">Load Initiative</button>
                     </div>
                 </div>
+
+                <!-- Right Column: Settings -->
+                <div id="initiative-settings-container" style="flex: 1; display: flex; flex-direction: column;">
+                    <h3>Settings</h3>
+                    <div class="list-container" style="flex-grow: 1; overflow-y: auto; background-color: #15191e; border: 1px solid #3f4c5a; padding: 10px;">
+                        <div class="setting-item">
+                            <label for="map-icon-size-slider">Map Icon Size</label>
+                            <input type="range" id="map-icon-size-slider" min="20" max="100" value="40">
+                            <span id="map-icon-size-value">40px</span>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div id="initiative-controls" style="margin-top: 20px; display: flex; justify-content: center; align-items: center; gap: 15px;">
                 <div id="initiative-timers" style="display: none; position: absolute; left: 20px; gap: 20px; background-color: #15191e; padding: 5px 10px; border-radius: 5px;">


### PR DESCRIPTION
This feature adds character tokens to the map when initiative starts.

Key features:
- Circular tokens are placed on the map for each character in initiative.
- Tokens display the character's profile image or initials.
- Tokens are initially arranged in initiative order and are fully draggable.
- A 'Map Icon Size' slider in the initiative settings allows the DM to change the size of all tokens.
- The current player's token is highlighted with a golden glow.
- The character's name and player's name are displayed underneath each token.
- Token positions, size, and current character HP values are saved and loaded with the campaign.