### PR TITLE
feat: Add token highlight refresh and refactor token sizing

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -304,8 +304,8 @@
                     <div class="list-container" style="flex-grow: 1; overflow-y: auto; background-color: #15191e; border: 1px solid #3f4c5a; padding: 10px;">
                         <div class="setting-item">
                             <label for="map-icon-size-slider">Map Icon Size</label>
-                            <input type="range" id="map-icon-size-slider" min="20" max="100" value="40">
-                            <span id="map-icon-size-value">40px</span>
+                            <input type="range" id="map-icon-size-slider" min="1" max="100" value="50">
+                            <span id="map-icon-size-value">50%</span>
                         </div>
                     </div>
                 </div>

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -130,7 +130,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let gameTime = 0;
     let initiativeRound = 0;
     let initiativeTokens = [];
-    let mapIconSize = 40;
+    let mapIconSizePercent = 50;
+    let calculatedIconPixelSize = 0;
     let isDraggingToken = false;
     let draggedToken = null;
     let dragStartX = 0;
@@ -170,6 +171,12 @@ document.addEventListener('DOMContentLoaded', () => {
         imgHeight: 0
     };
 
+
+    function calculateTokenPixelSize() {
+        if (!dmCanvas) return;
+        const maxPixelSize = Math.min(dmCanvas.width, dmCanvas.height) * 0.05;
+        calculatedIconPixelSize = maxPixelSize * (mapIconSizePercent / 100);
+    }
 
     // Debounce utility function
     function debounce(func, delay) {
@@ -211,6 +218,8 @@ document.addEventListener('DOMContentLoaded', () => {
             dmCanvas.height = canvasHeight;
             drawingCanvas.width = canvasWidth;
             drawingCanvas.height = canvasHeight;
+
+            calculateTokenPixelSize();
 
             if (mapWasDisplayed && currentFileNameToRedraw) {
                 displayMapOnCanvas(currentFileNameToRedraw);
@@ -292,12 +301,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function drawToken(ctx, token) {
         const canvasX = (token.x * currentMapDisplayData.ratio) + currentMapDisplayData.offsetX;
         const canvasY = (token.y * currentMapDisplayData.ratio) + currentMapDisplayData.offsetY;
-        const size = token.size * currentMapDisplayData.ratio;
+        const size = calculatedIconPixelSize;
 
         // Highlight for active turn
         if (initiativeTurn !== -1 && activeInitiative[initiativeTurn] && activeInitiative[initiativeTurn].uniqueId === token.uniqueId) {
             ctx.beginPath();
-            ctx.arc(canvasX, canvasY, (size / 2) + (5 * currentMapDisplayData.ratio), 0, Math.PI * 2, true);
+            ctx.arc(canvasX, canvasY, (size / 2) + 5, 0, Math.PI * 2, true);
             ctx.fillStyle = 'rgba(255, 215, 0, 0.7)'; // Golden glow
             ctx.fill();
         }
@@ -344,18 +353,18 @@ document.addEventListener('DOMContentLoaded', () => {
         ctx.beginPath();
         ctx.arc(canvasX, canvasY, size / 2, 0, Math.PI * 2, true);
         ctx.strokeStyle = 'black';
-        ctx.lineWidth = 2 * currentMapDisplayData.ratio;
+        ctx.lineWidth = 2;
         ctx.stroke();
 
         // Draw name and player name
         ctx.fillStyle = 'white';
         ctx.shadowColor = 'black';
         ctx.shadowBlur = 2;
-        ctx.font = `bold ${12 * currentMapDisplayData.ratio}px sans-serif`;
+        ctx.font = `bold 12px sans-serif`;
         ctx.textAlign = 'center';
-        ctx.fillText(token.name, canvasX, canvasY + size / 2 + (14 * currentMapDisplayData.ratio));
-        ctx.font = `${10 * currentMapDisplayData.ratio}px sans-serif`;
-        ctx.fillText(`(${token.playerName})`, canvasX, canvasY + size / 2 + (26 * currentMapDisplayData.ratio));
+        ctx.fillText(token.name, canvasX, canvasY + size / 2 + 14);
+        ctx.font = `10px sans-serif`;
+        ctx.fillText(`(${token.playerName})`, canvasX, canvasY + size / 2 + 26);
         ctx.shadowBlur = 0;
     }
 
@@ -795,7 +804,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function isPointInToken(point, token) {
-        const tokenRadius = (token.size / 2) / currentMapDisplayData.ratio; // Convert pixel radius to image coordinate radius
+        const tokenRadius = (calculatedIconPixelSize / 2) / currentMapDisplayData.ratio; // Convert canvas pixel radius to image coordinate radius
         const dx = point.x - token.x;
         const dy = point.y - token.y;
         const distance = Math.sqrt(dx * dx + dy * dy);
@@ -1595,7 +1604,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 savedInitiatives: savedInitiatives,
                 combatLog: diceDialogueRecord.innerHTML,
                 initiativeTokens: initiativeTokens,
-                mapIconSize: mapIconSize
+                mapIconSizePercent: mapIconSizePercent
             };
 
             const campaignJSON = JSON.stringify(campaignData, null, 2);
@@ -1700,9 +1709,10 @@ document.addEventListener('DOMContentLoaded', () => {
         savedRolls = [];
         renderSavedRolls();
         initiativeTokens = [];
-        mapIconSize = 40;
-        if (mapIconSizeSlider) mapIconSizeSlider.value = mapIconSize;
-        if (mapIconSizeValue) mapIconSizeValue.textContent = `${mapIconSize}px`;
+        mapIconSizePercent = 50;
+        if (mapIconSizeSlider) mapIconSizeSlider.value = mapIconSizePercent;
+        if (mapIconSizeValue) mapIconSizeValue.textContent = `${mapIconSizePercent}%`;
+        calculateTokenPixelSize();
     }
 
     function renderAllLists() {
@@ -1732,9 +1742,9 @@ document.addEventListener('DOMContentLoaded', () => {
         savedRolls = campaignData.savedRolls || [];
         savedInitiatives = campaignData.savedInitiatives || {};
         initiativeTokens = campaignData.initiativeTokens || [];
-        mapIconSize = campaignData.mapIconSize || 40;
-        if (mapIconSizeSlider) mapIconSizeSlider.value = mapIconSize;
-        if (mapIconSizeValue) mapIconSizeValue.textContent = `${mapIconSize}px`;
+        mapIconSizePercent = campaignData.mapIconSizePercent || 50;
+        if (mapIconSizeSlider) mapIconSizeSlider.value = mapIconSizePercent;
+        if (mapIconSizeValue) mapIconSizeValue.textContent = `${mapIconSizePercent}%`;
 
         if (campaignData.combatLog) {
             diceDialogueRecord.innerHTML = campaignData.combatLog;
@@ -1825,9 +1835,9 @@ document.addEventListener('DOMContentLoaded', () => {
         savedRolls = campaignData.savedRolls || [];
         savedInitiatives = campaignData.savedInitiatives || {};
         initiativeTokens = campaignData.initiativeTokens || [];
-        mapIconSize = campaignData.mapIconSize || 40;
-        if (mapIconSizeSlider) mapIconSizeSlider.value = mapIconSize;
-        if (mapIconSizeValue) mapIconSizeValue.textContent = `${mapIconSize}px`;
+        mapIconSizePercent = campaignData.mapIconSizePercent || 50;
+        if (mapIconSizeSlider) mapIconSizeSlider.value = mapIconSizePercent;
+        if (mapIconSizeValue) mapIconSizeValue.textContent = `${mapIconSizePercent}%`;
 
         if (campaignData.combatLog) {
             diceDialogueRecord.innerHTML = campaignData.combatLog;
@@ -4354,7 +4364,6 @@ function generateCharacterMarkdown(sheetData, notes, forPlayerView = false, isDe
                         uniqueId: character.uniqueId,
                         x: tokenX,
                         y: tokenY,
-                        size: mapIconSize,
                         name: character.name,
                         playerName: character.sheetData.player_name,
                         portrait: character.sheetData.character_portrait,
@@ -4428,6 +4437,9 @@ function generateCharacterMarkdown(sheetData, notes, forPlayerView = false, isDe
                 card.scrollIntoView({ behavior: 'smooth', block: 'center' });
             }
         }
+        if (selectedMapFileName) {
+            displayMapOnCanvas(selectedMapFileName);
+        }
     }
 
     function clearTurnHighlight() {
@@ -4469,12 +4481,10 @@ function generateCharacterMarkdown(sheetData, notes, forPlayerView = false, isDe
 
     if (mapIconSizeSlider && mapIconSizeValue) {
         mapIconSizeSlider.addEventListener('input', (e) => {
-            mapIconSize = parseInt(e.target.value, 10);
-            mapIconSizeValue.textContent = `${mapIconSize}px`;
+            mapIconSizePercent = parseInt(e.target.value, 10);
+            mapIconSizeValue.textContent = `${mapIconSizePercent}%`;
+            calculateTokenPixelSize();
             if (initiativeTokens.length > 0) {
-                initiativeTokens.forEach(token => {
-                    token.size = mapIconSize;
-                });
                 if (selectedMapFileName) {
                     displayMapOnCanvas(selectedMapFileName);
                 }


### PR DESCRIPTION
This commit addresses two follow-up items for the initiative tokens feature:

1.  **Token Highlight Refresh:** The active character's token highlight now updates instantly when the "Next Turn" button is clicked, without requiring a manual canvas refresh. This is achieved by adding a redraw call within the `highlightActiveTurn` function.

2.  **Token Sizing Refactor:** The token sizing mechanism has been refactored to be more flexible and responsive.
    -   The "Map Icon Size" slider now represents a percentage (1-100%) instead of a fixed pixel value.
    -   The token's pixel size is calculated based on this percentage relative to a maximum size, which is capped at 5% of the smaller dimension of the map view area.
    -   This makes the token size responsive to the window size.
    -   The token's size is now independent of the map's zoom level, providing a consistent size on the screen.
    -   The save/load functionality has been updated to persist the size percentage, ensuring compatibility across different screen resolutions.