### PR TITLE
Fix action log notifications and improve initiative icon sizing

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -304,8 +304,8 @@
                     <div class="list-container" style="flex-grow: 1; overflow-y: auto; background-color: #15191e; border: 1px solid #3f4c5a; padding: 10px;">
                         <div class="setting-item">
                             <label for="map-icon-size-slider">Map Icon Size</label>
-                            <input type="range" id="map-icon-size-slider" min="20" max="100" value="40">
-                            <span id="map-icon-size-value">40px</span>
+                            <input type="range" id="map-icon-size-slider" min="1" max="20" value="5">
+                            <span id="map-icon-size-value">5%</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This commit addresses two issues:
1. Action log notifications now disappear after 5 seconds as intended. Each notification has its own timer, which prevents the entire log from being dismissed when multiple notifications appear.
2. Initiative icon sizing is now relative to the map's width, ensuring a consistent appearance across maps of different resolutions. The slider has been updated to use percentages, and backward compatibility for old save files with pixel-based sizes is included.