### PR TITLE
Fix duplicate action log toasts

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3728,8 +3728,6 @@ function displayToast(messageElement) {
             diceDialogueRecord.prepend(messageElement);
         }
 
-        diceDialogueRecord.style.display = 'flex';
-
     displayToast(messageElement);
     }
 
@@ -4405,7 +4403,6 @@ function displayToast(messageElement) {
 
                 const startEvent = createLogEntry("Combat Started");
                 diceDialogueRecord.prepend(startEvent);
-                diceDialogueRecord.style.display = 'flex';
                 displayToast(startEvent);
 
                 startInitiativeButton.textContent = 'Stop Initiative';


### PR DESCRIPTION
I've fixed a follow-up issue where new action log messages would cause the main log container to appear, in addition to the new toast notification, creating a duplicate message.

I removed the lines that programmatically set `display: 'flex'` on the `#dice-dialogue-record` container from the `showDiceDialogue` and `startInitiativeButton` functions. The container's visibility is now managed only by you opening or closing the persistent action log.