### PR TITLE
feat: Implement initiative token mini-stat block

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -277,6 +277,70 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.token-stat-block {
+    background-color: #2a3138;
+    border: 1px solid #3f4c5a;
+    border-radius: 5px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.5);
+    z-index: 1002;
+    color: #e0e0e0;
+    padding: 10px;
+    width: 250px;
+}
+
+.token-stat-block-content h4, .token-stat-block-content p {
+    margin: 0 0 5px 0;
+    text-align: center;
+}
+
+.token-stat-block-content .stat-block-health {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.token-stat-block-content .token-stat-block-hp-input {
+    width: 50px;
+    margin: 0 5px;
+    background-color: #15191e;
+    color: #e0e0e0;
+    border: 1px solid #3f4c5a;
+}
+
+.token-stat-block-content .stat-block-rolls {
+    border-top: 1px solid #3f4c5a;
+    margin-top: 10px;
+    padding-top: 10px;
+}
+
+.token-stat-block-content .stat-block-rolls h5 {
+    margin: 0 0 5px 0;
+}
+
+.token-stat-block-content #token-stat-block-rolls-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 10px 0;
+}
+
+.token-stat-block-content #token-stat-block-rolls-list li {
+    display: flex;
+    justify-content: space-between;
+    padding: 3px 0;
+}
+
+.token-stat-block-content .add-roll-form {
+    display: flex;
+    gap: 5px;
+}
+
+.token-stat-block-content .add-roll-form input {
+    flex-grow: 1;
+    background-color: #15191e;
+    color: #e0e0e0;
+    border: 1px solid #3f4c5a;
+}
+
 /* Toast Notification Styles */
 #toast-container {
     position: fixed;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -323,5 +323,27 @@
     </div>
     <div id="dice-dialogue-record" class="dice-dialogue"></div>
     <div id="toast-container"></div>
+
+    <div id="token-stat-block" class="token-stat-block" style="display: none; position: absolute; z-index: 1003;">
+        <div class="token-stat-block-content">
+            <h4 id="token-stat-block-char-name"></h4>
+            <p id="token-stat-block-player-name"></p>
+            <div class="stat-block-health">
+                <label for="token-stat-block-hp">HP:</label>
+                <input type="number" id="token-stat-block-hp" class="token-stat-block-hp-input">
+                <span id="token-stat-block-max-hp"></span>
+            </div>
+            <button id="token-stat-block-set-targets">Set Targets</button>
+            <div class="stat-block-rolls">
+                <h5>Rolls</h5>
+                <ul id="token-stat-block-rolls-list"></ul>
+                <div class="add-roll-form">
+                    <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name">
+                    <input type="text" id="token-stat-block-add-roll-dice" placeholder="e.g. 1d20+5">
+                    <button id="token-stat-block-add-roll-btn">Add</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This feature introduces a floating mini-stat block that appears when a character's token is clicked in the initiative tracker.

The stat block displays:
- Character and player name
- Editable current health
- A 'Set Targets' button
- A customizable list of saved rolls for the character

You can add and remove custom rolls directly from the stat block. All changes, including health and custom rolls, are persisted when the campaign is saved.