### PR TITLE
Refactor character overlay custom dice roll section

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -277,6 +277,20 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.dice-button-compact {
+    padding: 5px;
+    font-size: 12px;
+    background-color: #3a4f6a;
+    color: #e0e0e0;
+    border: 1px solid #5f6a7a;
+}
+
+.dice-button-compact .dice-count {
+    font-weight: bold;
+    margin-left: 4px;
+    color: #b6cae1;
+}
+
 .token-stat-block {
     background-color: #2a3138;
     border: 1px solid #3f4c5a;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -337,10 +337,22 @@
             <div class="stat-block-rolls">
                 <h5>Rolls</h5>
                 <ul id="token-stat-block-rolls-list"></ul>
-                <div class="add-roll-form">
-                    <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name">
-                    <input type="text" id="token-stat-block-add-roll-dice" placeholder="e.g. 1d20+5">
-                    <button id="token-stat-block-add-roll-btn">Add</button>
+                <div id="token-stat-block-add-roll-form" class="add-roll-form">
+                    <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name" style="width: 100%; margin-bottom: 5px;">
+                    <div id="token-stat-block-dice-buttons" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; margin-bottom: 5px;">
+                        <button class="dice-button-compact" data-die="d4">d4 <span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d6">d6 <span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d8">d8 <span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d10">d10 <span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d12">d12 <span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d20">d20 <span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d100">d100 <span class="dice-count"></span></button>
+                    </div>
+                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                        <label for="token-stat-block-add-roll-modifier">Modifier:</label>
+                        <input type="number" id="token-stat-block-add-roll-modifier" value="0" style="width: 60px;">
+                    </div>
+                    <button id="token-stat-block-save-roll-btn" style="width: 100%;">Save</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Replaces the plain text input for custom rolls in the character stat block overlay with a compact, interactive dice roller.

This new UI allows you to build a dice roll by clicking buttons for different die types (d4, d6, d8, d10, d12, d20, d100) and setting a modifier. The dice configuration is saved to the character in a structured format, `{ name, dice: {...}, modifier }`.

The list of saved rolls now displays the full dice string (e.g., "2d6 + 5") and includes a "Roll" button to execute the roll with a single click, in addition to the existing "Delete" button. The roll results are displayed in the action log, consistent with other dice rolls in the application.