### PR TITLE
Fix: Correct stat block UI and campaign load toast bug

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -300,6 +300,8 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #e0e0e0;
     padding: 10px;
     width: 250px;
+    max-height: 400px;
+    overflow-y: auto;
 }
 
 .token-stat-block-content h4, .token-stat-block-content p {
@@ -345,14 +347,56 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 
 .token-stat-block-content .add-roll-form {
     display: flex;
+    flex-direction: column;
     gap: 5px;
 }
 
-.token-stat-block-content .add-roll-form input {
+#token-stat-block-add-roll-name, #token-stat-block-save-roll-btn {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+#token-stat-block-dice-buttons {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+    gap: 3px;
+}
+
+.dice-button-compact {
+    padding: 3px;
+    font-size: 11px;
+}
+
+.modifier-form {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modifier-form input {
+    width: 50px;
+}
+
+.token-stat-block-content #token-stat-block-rolls-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2px 0;
+    margin-bottom: 2px;
+}
+
+.token-stat-block-content #token-stat-block-rolls-list .roll-name {
     flex-grow: 1;
-    background-color: #15191e;
-    color: #e0e0e0;
-    border: 1px solid #3f4c5a;
+    margin-right: 5px;
+    font-size: 0.9em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.token-stat-block-content #token-stat-block-rolls-list .roll-actions button {
+    padding: 2px 5px;
+    font-size: 11px;
 }
 
 /* Toast Notification Styles */

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -338,21 +338,21 @@
                 <h5>Rolls</h5>
                 <ul id="token-stat-block-rolls-list"></ul>
                 <div id="token-stat-block-add-roll-form" class="add-roll-form">
-                    <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name" style="width: 100%; margin-bottom: 5px;">
-                    <div id="token-stat-block-dice-buttons" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; margin-bottom: 5px;">
-                        <button class="dice-button-compact" data-die="d4">d4 <span class="dice-count"></span></button>
-                        <button class="dice-button-compact" data-die="d6">d6 <span class="dice-count"></span></button>
-                        <button class="dice-button-compact" data-die="d8">d8 <span class="dice-count"></span></button>
-                        <button class="dice-button-compact" data-die="d10">d10 <span class="dice-count"></span></button>
-                        <button class="dice-button-compact" data-die="d12">d12 <span class="dice-count"></span></button>
-                        <button class="dice-button-compact" data-die="d20">d20 <span class="dice-count"></span></button>
-                        <button class="dice-button-compact" data-die="d100">d100 <span class="dice-count"></span></button>
+                    <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name">
+                    <div id="token-stat-block-dice-buttons">
+                        <button class="dice-button-compact" data-die="d4">d4<span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d6">d6<span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d8">d8<span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d10">d10<span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d12">d12<span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d20">d20<span class="dice-count"></span></button>
+                        <button class="dice-button-compact" data-die="d100">d100<span class="dice-count"></span></button>
                     </div>
-                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <div class="modifier-form">
                         <label for="token-stat-block-add-roll-modifier">Modifier:</label>
-                        <input type="number" id="token-stat-block-add-roll-modifier" value="0" style="width: 60px;">
+                        <input type="number" id="token-stat-block-add-roll-modifier" value="0">
                     </div>
-                    <button id="token-stat-block-save-roll-btn" style="width: 100%;">Save</button>
+                    <button id="token-stat-block-save-roll-btn">Save</button>
                 </div>
             </div>
         </div>

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1918,7 +1918,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (campaignData.combatLog) {
             diceDialogueRecord.innerHTML = campaignData.combatLog;
-            diceDialogueRecord.style.display = 'flex';
         } else {
             diceDialogueRecord.innerHTML = '';
             diceRollHistory.forEach(historyMessage => {
@@ -2018,7 +2017,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (campaignData.combatLog) {
             diceDialogueRecord.innerHTML = campaignData.combatLog;
-            diceDialogueRecord.style.display = 'flex';
         }
 
         if (campaignData.mapDefinitions) {


### PR DESCRIPTION
This commit addresses two issues:
1.  The character token stat block UI for the new custom dice roller has been fixed. The container is now scrollable, and the internal elements have been resized and rearranged to prevent overflow and improve the layout.

2.  A bug causing a persistent toast message to appear on campaign load has been fixed. The action log is now correctly populated in the background without being incorrectly displayed. This was resolved by removing the line of code that was setting the display property of the action log container during the campaign loading process.