### PR TITLE
fix: Restore note and character preview functionality

### DIFF
--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -254,10 +254,16 @@
         </div>
     </div>
     <div id="note-preview-overlay" class="note-preview-overlay" style="display: none;">
-        <!-- ... note preview content ... -->
+        <div class="note-preview-content">
+            <div id="note-preview-body"></div>
+        </div>
     </div>
+
     <div id="character-preview-overlay" class="note-preview-overlay" style="display: none;">
-        <!-- ... character preview content ... -->
+        <div class="note-preview-content">
+            <button id="character-preview-close" class="note-preview-close">&times;</button>
+            <div id="character-preview-body"></div>
+        </div>
     </div>
     <script src="quote_map.json"></script>
     <script src="player_view.js"></script>


### PR DESCRIPTION
This commit fixes a regression where note and character preview overlays were not appearing on the player view.

The issue was caused by the accidental removal of the inner HTML content of the `#note-preview-overlay` and `#character-preview-overlay` divs in `player_view.html` during a previous refactoring. This change restores the necessary child elements (`#note-preview-body`, `#character-preview-body`, etc.), allowing the JavaScript to correctly populate and display the overlays when triggered by the DM.