### PR TITLE
feat: Add Wander mode for non-combat token management

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -317,6 +317,7 @@
                 </div>
                 <button id="prev-turn-button" style="display: none;">&lt; Prev</button>
                 <button id="start-initiative-button">Start Initiative</button>
+                <button id="wander-button">Wander</button>
                 <button id="next-turn-button" style="display: none;">Next &gt;</button>
             </div>
         </div>


### PR DESCRIPTION
This commit introduces a new 'Wander' mode to the initiative tracker. This feature allows the Dungeon Master to place character tokens on the map for non-combat encounters without starting a full, turn-based initiative.

Key features of Wander mode:
- A new 'Wander' button is added to the initiative controls.
- Clicking 'Wander' places all characters from the active initiative list onto the map as movable tokens.
- In this mode, tokens can be moved, resized, and their stat blocks can be viewed. There are no turns or timers.
- All token states and movements are synchronized to the player view in real-time.
- The 'Wander' button toggles to 'Stop Wandering' to remove the tokens from the map.
- Starting a formal initiative will automatically end the Wander mode.
- The wandering state, including token positions, is saved and loaded with the campaign.