### PR TITLE
fix: Persist HP changes from initiative tracker to master character s…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -4633,9 +4633,20 @@ function displayToast(messageElement) {
 
             const hpInput = card.querySelector('[data-hp-input]');
             hpInput.addEventListener('change', (e) => {
-                const char = activeInitiative.find(c => c.uniqueId == e.target.dataset.characterId);
-                if(char) {
-                    char.sheetData.hp_current = e.target.value;
+                const charInInitiative = activeInitiative.find(c => c.uniqueId == e.target.dataset.characterId);
+                if (charInInitiative) {
+                    const newHp = e.target.value;
+                    // Update the character in the active initiative list
+                    charInInitiative.sheetData.hp_current = newHp;
+
+                    // Find and update the corresponding character in the master list
+                    const mainCharacter = charactersData.find(c => c.id === charInInitiative.id);
+                    if (mainCharacter) {
+                        if (!mainCharacter.sheetData) mainCharacter.sheetData = {};
+                        mainCharacter.sheetData.hp_current = newHp;
+                    }
+
+                    // Let the player view know about the change
                     sendInitiativeDataToPlayerView();
                 }
             });


### PR DESCRIPTION
…heet

This commit fixes a bug where changes to a character's HP made directly in the initiative tracker list were not being saved to the character's main data object. This meant the change was only temporary for the combat and not reflected if the character sheet was viewed later.

The event listener for the HP input field in the initiative tracker now correctly finds the corresponding character in the master `charactersData` array and updates its `hp_current` value. This ensures data consistency, so that any HP change made during combat is permanently reflected on the character's sheet.