### PR TITLE
Fix: Correct UI and data synchronization bugs

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3849,6 +3849,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 const character = charactersData.find(c => c.id === selectedCharacterId);
                 if (character) {
                     character.sheetData = event.data.data;
+
+                    // Propagate changes to any instance of this character in the active initiative
+                    activeInitiative.forEach(activeChar => {
+                        if (activeChar.id === selectedCharacterId) {
+                            activeChar.sheetData = character.sheetData;
+                        }
+                    });
+
+                    // Rerender lists and tokens to show updated info
+                    renderActiveInitiativeList();
+                    if (selectedMapFileName) {
+                        displayMapOnCanvas(selectedMapFileName);
+                    }
+                    sendInitiativeDataToPlayerView();
                 }
             }
         } else if (event.data.type === 'characterSheetReady') {
@@ -4796,6 +4810,7 @@ function displayToast(messageElement) {
         initiativeTrackerOverlay.addEventListener('click', (event) => {
             if (event.target === initiativeTrackerOverlay) {
                 initiativeTrackerOverlay.style.display = 'none';
+                sendInitiativeTrackerStateToPlayerView(false);
             }
         });
     }
@@ -4974,6 +4989,14 @@ function displayToast(messageElement) {
                 nextTurnButton.style.display = 'none';
                 prevTurnButton.style.display = 'none';
                 clearTurnHighlight();
+
+                // Hide token stat block on both DM and player views when initiative ends
+                if (selectedTokenForStatBlock) {
+                    tokenStatBlock.style.display = 'none';
+                    selectedTokenForStatBlock = null;
+                    sendTokenStatBlockStateToPlayerView(false);
+                }
+
                 sendInitiativeDataToPlayerView();
             }
         });


### PR DESCRIPTION
This commit addresses several issues related to UI persistence on the player view and data synchronization between the character sheet, initiative tracker, and tokens.

1.  **Player View UI Fixes:**
    -   The token stat block on the player's view now correctly disappears when the initiative encounter ends.
    -   The initiative tracker overlay on the player's view now closes in sync with the DM's view when the DM clicks the overlay background to dismiss it.

2.  **Character Data Synchronization:**
    -   When a character's master sheet is saved, the updated data (e.g., max HP, name, etc.) is now immediately propagated to that character's instance in the active initiative list.
    -   This ensures that the initiative list, tokens on the map, and the token stat block all reflect the most current character data, resolving the bug where tokens would not update after a character sheet was modified.