### PR TITLE
Fix: Hide token stat block when wandering ends

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -5010,6 +5010,14 @@ function displayToast(messageElement) {
                 wanderButton.textContent = 'Wander';
                 initiativeTokens = [];
                 createLogEntry("Stopped Wandering");
+
+                // Hide token stat block on both DM and player views when wandering ends
+                if (selectedTokenForStatBlock) {
+                    tokenStatBlock.style.display = 'none';
+                    selectedTokenForStatBlock = null;
+                    sendTokenStatBlockStateToPlayerView(false);
+                }
+
                 if (selectedMapFileName) {
                     displayMapOnCanvas(selectedMapFileName);
                 }


### PR DESCRIPTION
This commit addresses an oversight from the previous fix. The logic to hide the token character card (`token-stat-block`) was not applied to the 'Stop Wandering' function.

This change adds the necessary logic to the `wanderButton` event listener. Now, when wandering is stopped, it will correctly hide any open token stat block on both the DM and player views, preventing the UI element from getting stuck on the screen.