### PR TITLE
Fix: Correctly sync player view stat block on close

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2568,6 +2568,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (tokenStatBlock.style.display === 'block' && !tokenStatBlock.contains(event.target) && !dmCanvas.contains(event.target)) {
             tokenStatBlock.style.display = 'none';
             selectedTokenForStatBlock = null;
+        sendTokenStatBlockStateToPlayerView(false);
         }
     });
 


### PR DESCRIPTION
This commit provides a more robust fix for the issue where the token stat block would remain on the player's view.

The root cause was identified as a global 'click-off' event listener that would close the stat block on the DM's view but failed to notify the player's view. This event was firing before the more specific button-click handlers, nullifying the previous fixes.

This patch adds the necessary synchronization call to the global click listener, ensuring that any action that closes the DM-side stat block will now correctly close the player-side one as well. This resolves the bug for all cases, including ending an initiative or a wander.