### PR TITLE
Feat: Increase token health bar thickness

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -348,7 +348,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!isNaN(maxHp) && !isNaN(currentHp) && maxHp > 0) {
                 const healthPercentage = Math.max(0, currentHp / maxHp);
                 const ringRadius = (size / 2) + (8 * currentMapDisplayData.ratio);
-                const ringWidth = 3 * currentMapDisplayData.ratio;
+                const ringWidth = 6 * currentMapDisplayData.ratio;
 
                 // Red background ring
                 ctx.beginPath();

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -582,7 +582,7 @@ function drawToken(ctx, token) {
         if (!isNaN(maxHp) && !isNaN(currentHp) && maxHp > 0) {
             const healthPercentage = Math.max(0, currentHp / maxHp);
             const ringRadius = (size / 2) + (8 * currentMapDisplayData.ratio);
-            const ringWidth = 3 * currentMapDisplayData.ratio;
+            const ringWidth = 6 * currentMapDisplayData.ratio;
 
             ctx.beginPath();
             ctx.arc(canvasX, canvasY, ringRadius, 0, Math.PI * 2, false);


### PR DESCRIPTION
This commit doubles the thickness of the token health bars for improved visibility. The ring width is now 6 pixels instead of 3.

This change has been applied to both the DM view and the Player view to ensure a consistent appearance.