### PR TITLE
feat: Implement selective save and merge-on-load

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -325,6 +325,56 @@
     <div id="dice-dialogue-record" class="dice-dialogue"></div>
     <div id="toast-container"></div>
 
+    <div id="save-campaign-modal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button" id="save-campaign-modal-close-button">&times;</span>
+            <h3>Select Campaign Data to Save</h3>
+            <div id="save-options-container">
+                <div class="save-option">
+                    <input type="checkbox" id="save-maps-checkbox" name="maps" value="maps" checked>
+                    <label for="save-maps-checkbox">Maps & Map Links</label>
+                </div>
+                <div class="save-option">
+                    <input type="checkbox" id="save-characters-checkbox" name="characters" value="characters" checked>
+                    <label for="save-characters-checkbox">Characters</label>
+                </div>
+                <div class="save-option">
+                    <input type="checkbox" id="save-notes-checkbox" name="notes" value="notes" checked>
+                    <label for="save-notes-checkbox">Notes</label>
+                </div>
+                <div class="save-option">
+                    <input type="checkbox" id="save-initiative-checkbox" name="initiative" value="initiative" checked>
+                    <label for="save-initiative-checkbox">Initiative</label>
+                </div>
+                <div class="save-option">
+                    <input type="checkbox" id="save-rolls-checkbox" name="rolls" value="rolls" checked>
+                    <label for="save-rolls-checkbox">Dice Rolls & History</label>
+                </div>
+            </div>
+            <div id="save-conflict-warnings" style="color: yellow; margin-top: 10px;"></div>
+            <div style="margin-top: 20px;">
+                <button id="confirm-save-button">Save</button>
+                <button id="cancel-save-button">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="load-campaign-modal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button" id="load-campaign-modal-close-button">&times;</span>
+            <h3>Select Campaign Data to Load</h3>
+            <p>The following data was found in the campaign file. Select the items you wish to load.</p>
+            <div id="load-options-container">
+                <!-- Checkboxes will be dynamically populated by Javascript -->
+            </div>
+            <div id="load-conflict-warnings" style="color: yellow; margin-top: 10px;"></div>
+            <div style="margin-top: 20px;">
+                <button id="confirm-load-button">Load Selected</button>
+                <button id="cancel-load-button">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <div id="token-stat-block" class="token-stat-block" style="display: none; position: absolute; z-index: 1003;">
         <div class="token-stat-block-content">
             <h4 id="token-stat-block-char-name"></h4>


### PR DESCRIPTION
This commit introduces a major enhancement to the campaign save and load functionality.

Key changes:
- **Selective Save**: When saving a campaign, a dialog now appears allowing the user to select which components of the campaign to save (e.g., maps, characters, notes). This enables more granular control over campaign data. Dependency checks are included to prevent inconsistent saves (e.g., saving a map with a note link requires saving notes as well).
- **Merge on Load**: When loading a campaign from a zip file, a dialog appears showing which data categories are present in the file. The user can select which categories to import. The imported data is then merged with the existing campaign data, rather than overwriting it completely. New items are added, and existing items are skipped to prevent data loss.
- **New Filename Format**: Saved campaign files are now named `DnDemicube_campaign_[MM-DD-YY].zip`.
- **UI Enhancements**: New modals have been added for the save and load processes to accommodate these new options.

These changes allow for greater flexibility in managing campaign data, such as transferring characters or notes between different campaigns.