### PR TITLE
feat: Implement selective save and merge-on-load

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1,4 +1,22 @@
 document.addEventListener('DOMContentLoaded', () => {
+    const saveCampaignModal = document.getElementById('save-campaign-modal');
+    const saveCampaignModalCloseButton = document.getElementById('save-campaign-modal-close-button');
+    const confirmSaveButton = document.getElementById('confirm-save-button');
+    const cancelSaveButton = document.getElementById('cancel-save-button');
+    const saveOptionsContainer = document.getElementById('save-options-container');
+    const saveConflictWarnings = document.getElementById('save-conflict-warnings');
+    const saveMapsCheckbox = document.getElementById('save-maps-checkbox');
+    const saveCharactersCheckbox = document.getElementById('save-characters-checkbox');
+    const saveNotesCheckbox = document.getElementById('save-notes-checkbox');
+    const saveInitiativeCheckbox = document.getElementById('save-initiative-checkbox');
+    const saveRollsCheckbox = document.getElementById('save-rolls-checkbox');
+
+    const loadCampaignModal = document.getElementById('load-campaign-modal');
+    const loadCampaignModalCloseButton = document.getElementById('load-campaign-modal-close-button');
+    const loadOptionsContainer = document.getElementById('load-options-container');
+    const confirmLoadButton = document.getElementById('confirm-load-button');
+    const cancelLoadButton = document.getElementById('cancel-load-button');
+
     const uploadMapsInput = document.getElementById('upload-maps-input');
     const mapsList = document.getElementById('maps-list');
     const openPlayerViewButton = document.getElementById('open-player-view-button'); // Added for player view


### PR DESCRIPTION
This commit introduces a major enhancement to the campaign save and load functionality.

Key changes:
- **Selective Save**: When saving a campaign, a dialog now appears allowing the user to select which components of the campaign to save (e.g., maps, characters, notes). This enables more granular control over campaign data. Dependency checks are included to prevent inconsistent saves (e.g., saving a map with a note link requires saving notes as well).
- **Merge on Load**: When loading a campaign from a zip file, a dialog appears showing which data categories are present in the file. The user can select which categories to import. The imported data is then merged with the existing campaign data, rather than overwriting it completely. New items are added, and existing items are skipped to prevent data loss.
- **New Filename Format**: Saved campaign files are now named `DnDemicube_campaign_[MM-DD-YY].zip`.
- **UI Enhancements**: New modals have been added for the save and load processes to accommodate these new options.

These changes allow for greater flexibility in managing campaign data, such as transferring characters or notes between different campaigns.

fix: Correct reference errors and logic in load modal

This commit also fixes a set of bugs that were introduced during development:
- Moves all modal-related constant declarations to the top of the script to prevent ReferenceErrors due to scoping issues.
- Corrects a logic bug in the load modal's close button event handling.