### PR TITLE
feat: Implement 'Set Targets' and custom roll logic

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -277,6 +277,15 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+body.targeting {
+    cursor: crosshair;
+}
+
+#token-stat-block-set-targets.active {
+    background-color: #ff4d4d;
+    color: white;
+}
+
 .dice-button-compact {
     padding: 5px;
     font-size: 12px;
@@ -351,9 +360,17 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     gap: 5px;
 }
 
-#token-stat-block-add-roll-name, #token-stat-block-save-roll-btn {
+#token-stat-block-add-roll-name, #token-stat-block-add-roll-tags, #token-stat-block-save-roll-btn {
     width: 100%;
     box-sizing: border-box;
+}
+
+#token-stat-block-add-roll-tags {
+    margin-bottom: 5px;
+    background-color: #15191e;
+    border: 1px solid #3f4c5a;
+    color: #e0e0e0;
+    padding: 5px;
 }
 
 #token-stat-block-dice-buttons {

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -390,6 +390,7 @@
                 <ul id="token-stat-block-rolls-list"></ul>
                 <div id="token-stat-block-add-roll-form" class="add-roll-form">
                     <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name">
+                    <input type="text" id="token-stat-block-add-roll-tags" placeholder="Tags (e.g. Hit, Damage)">
                     <div id="token-stat-block-dice-buttons">
                         <button class="dice-button-compact" data-die="d4">d4<span class="dice-count"></span></button>
                         <button class="dice-button-compact" data-die="d6">d6<span class="dice-count"></span></button>


### PR DESCRIPTION
This commit implements the full functionality for the 'set targets' button and creates custom logic to automatically process specific types of rolls against a targeted character.

The 'set targets' button now enables the user to select one or more other characters in the initiative as targets.

Custom Functions for Rolls:
- 'Hit' Tag: When a character with a target performs a roll tagged as 'Hit', the system will automatically compare the roll result against the target's Armor Class (AC). A message card indicating 'hit' or 'miss' will be generated in the action log.
- 'Damage' Tag: When a character with a target performs a roll tagged as 'Damage', the system will apply the resulting damage directly to the target character, automatically updating their health.
- Skill Checks: When a character with a target performs a skill roll, the system will initiate a contested skill check. Both the attacking character and the target character will roll the same skill, and the system will automatically determine the winner and record the outcome in the action log.

The save and upload campaign functionality has been updated to be compatible with these changes, and previous versions of the save and upload zip files are still supported.