### PR TITLE
Fix toast notifications and improve character targeting

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -385,6 +385,10 @@
                 <span id="token-stat-block-max-hp"></span>
             </div>
             <button id="token-stat-block-set-targets">Set Targets</button>
+            <div id="token-stat-block-targets-container" style="display: none;">
+                <h5>Targets</h5>
+                <ul id="token-stat-block-targets-list"></ul>
+            </div>
             <div class="stat-block-rolls">
                 <h5>Rolls</h5>
                 <ul id="token-stat-block-rolls-list"></ul>

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -458,7 +458,7 @@ window.addEventListener('message', (event) => {
                 }
                 break;
             case 'toast':
-                displayToast(createDiceRollCard(data.rollData));
+                displayToast(createLogCard(data.rollData));
                 break;
             case 'initiativeDataUpdate':
                 activeInitiative = data.activeInitiative || [];
@@ -499,36 +499,43 @@ function getInitials(name) {
     return name.substring(0, 2);
 }
 
-function createDiceRollCard(rollData) {
+function createLogCard(data) {
     const messageElement = document.createElement('div');
     messageElement.classList.add('dice-dialogue-message');
 
     const cardContent = document.createElement('div');
-    cardContent.classList.add('dice-roll-card-content');
+    cardContent.classList.add('dice-roll-card-content'); // Reuse styles
     messageElement.appendChild(cardContent);
 
-    const profilePic = document.createElement('div');
-    profilePic.classList.add('dice-roll-profile-pic');
-    if (rollData.characterPortrait) {
-        profilePic.style.backgroundImage = `url('${rollData.characterPortrait}')`;
-    } else {
-        profilePic.textContent = rollData.characterInitials || getInitials(rollData.characterName);
+    if (data.type === 'roll') {
+        const profilePic = document.createElement('div');
+        profilePic.classList.add('dice-roll-profile-pic');
+        if (data.characterPortrait) {
+            profilePic.style.backgroundImage = `url('${data.characterPortrait}')`;
+        } else {
+            profilePic.textContent = data.characterInitials || getInitials(data.characterName);
+        }
+        cardContent.appendChild(profilePic);
+
+        const textContainer = document.createElement('div');
+        textContainer.classList.add('dice-roll-text-container');
+        cardContent.appendChild(textContainer);
+
+        const namePara = document.createElement('p');
+        namePara.classList.add('dice-roll-name');
+        namePara.innerHTML = `<strong>${data.characterName}</strong> played by <strong>${data.playerName}</strong>`;
+        textContainer.appendChild(namePara);
+
+        const detailsPara = document.createElement('p');
+        detailsPara.classList.add('dice-roll-details');
+        detailsPara.innerHTML = `<strong class="dice-roll-sum-text">${data.sum}</strong> | ${data.roll}`;
+        textContainer.appendChild(detailsPara);
+    } else { // System or Note
+        const detailsPara = document.createElement('p');
+        detailsPara.classList.add('dice-roll-details');
+        detailsPara.innerHTML = data.message;
+        cardContent.appendChild(detailsPara);
     }
-    cardContent.appendChild(profilePic);
-
-    const textContainer = document.createElement('div');
-    textContainer.classList.add('dice-roll-text-container');
-    cardContent.appendChild(textContainer);
-
-    const namePara = document.createElement('p');
-    namePara.classList.add('dice-roll-name');
-    namePara.innerHTML = `<strong>${rollData.characterName}</strong> played by <strong>${rollData.playerName}</strong>`;
-    textContainer.appendChild(namePara);
-
-    const detailsPara = document.createElement('p');
-    detailsPara.classList.add('dice-roll-details');
-    detailsPara.innerHTML = `<strong class="dice-roll-sum-text">${rollData.sum}</strong> | ${rollData.roll}`;
-    textContainer.appendChild(detailsPara);
 
     return messageElement;
 }


### PR DESCRIPTION
This commit addresses two bugs:

1.  Toast notifications for action log entries now appear for all message types (e.g., 'combat started', 'hit roll'), not just dice rolls. This fix applies to both the DM and player views.

2.  The character targeting functionality has been improved:
    - The character menu is now hidden during targeting to prevent it from obscuring the map.
    - Targeted characters are now highlighted with a red ring, matching the style of the active turn indicator.
    - Targeting can now be finished by clicking the character who initiated the targeting.
    - A list of selected targets is now displayed on the character card after targeting is complete.