### PR TITLE
fix: Correct dice dialogue function call and add new roll tags

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -394,7 +394,18 @@
                 <ul id="token-stat-block-rolls-list"></ul>
                 <div id="token-stat-block-add-roll-form" class="add-roll-form">
                     <input type="text" id="token-stat-block-add-roll-name" placeholder="Roll Name">
-                    <input type="text" id="token-stat-block-add-roll-tags" placeholder="Tags (e.g. Hit, Damage)">
+                    <select id="token-stat-block-add-roll-tags">
+                        <option value="">None</option>
+                        <option value="Hit">Hit</option>
+                        <option value="Damage">Damage</option>
+                        <option value="Healing">Healing</option>
+                        <option value="Strength">Strength</option>
+                        <option value="Dexterity">Dexterity</option>
+                        <option value="Constitution">Constitution</option>
+                        <option value="Intelligence">Intelligence</option>
+                        <option value="Wisdom">Wisdom</option>
+                        <option value="Charisma">Charisma</option>
+                    </select>
                     <div id="token-stat-block-dice-buttons">
                         <button class="dice-button-compact" data-die="d4">d4<span class="dice-count"></span></button>
                         <button class="dice-button-compact" data-die="d6">d6<span class="dice-count"></span></button>


### PR DESCRIPTION
- Fixes a `ReferenceError` for `showDiceDialogue` by replacing the incorrect function call with `addLogEntry`.
- Replaces the free-text input for roll tags with a dropdown menu for better usability and control.
- Adds new tags for "Healing" and ability scores (Strength, Dexterity, Constitution, Intelligence, Wisdom, Charisma).
- Implements logic for the "Healing" tag to correctly restore HP to selected targets.
- Implements logic for ability score tags to perform a contested roll against the target's corresponding saving throw, with the result posted to the action log.