### PR TITLE
feat: Add DM screen footer with notes and campaign timer

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -277,6 +277,52 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* Footer Styles */
+#dm-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: #20262d;
+    border-top: 1px solid #3f4c5a;
+    padding: 8px 15px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-sizing: border-box;
+    z-index: 1002; /* Ensure it's above map but below modals */
+}
+
+#footer-notes-area {
+    flex-grow: 1;
+    margin-right: 20px;
+}
+
+#dm-notes-input {
+    width: 100%;
+    padding: 8px;
+    background-color: #15191e;
+    border: 1px solid #3f4c5a;
+    color: #e0e0e0;
+    border-radius: 4px;
+}
+
+#footer-timer-area {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#campaign-timer-display {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 1.2em;
+    color: #b6cae1;
+    background-color: #15191e;
+    padding: 5px 10px;
+    border-radius: 4px;
+    border: 1px solid #3f4c5a;
+}
+
 body.targeting {
     cursor: crosshair;
 }

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -350,6 +350,10 @@
                     <input type="checkbox" id="save-rolls-checkbox" name="rolls" value="rolls" checked>
                     <label for="save-rolls-checkbox">Dice Rolls & History</label>
                 </div>
+                <div class="save-option">
+                    <input type="checkbox" id="save-timer-checkbox" name="timer" value="timer" checked>
+                    <label for="save-timer-checkbox">Campaign Timer</label>
+                </div>
             </div>
             <div id="save-conflict-warnings" style="color: yellow; margin-top: 10px;"></div>
             <div style="margin-top: 20px;">
@@ -424,5 +428,14 @@
             </div>
         </div>
     </div>
+    <footer id="dm-footer">
+        <div id="footer-notes-area">
+            <input type="text" id="dm-notes-input" placeholder="Type a note and press Enter...">
+        </div>
+        <div id="footer-timer-area">
+            <span id="campaign-timer-display">00:00:00</span>
+            <button id="campaign-timer-toggle">Resume Campaign</button>
+        </div>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a new footer to the DM screen, providing tools for real-time session management.

Key features include:
- A dedicated footer section at the bottom of the DM screen.
- A DM notes area that allows for quick note-taking, sending notes to the Activity Log upon pressing Enter.
- A campaign timer with pause/resume functionality, which also logs events to the Activity Log.
- Integration of the campaign timer's state with the save/load system, ensuring time is tracked across sessions.
- Backward compatibility for loading older save files that do not contain timer data.