### PR TITLE
feat: Add audio recording and fix footer overlap

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -1,4 +1,4 @@
-body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; background-color: #15191e; color: #e0e0e0; }
+body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; background-color: #15191e; color: #e0e0e0; padding-bottom: 60px; /* Added to prevent footer overlap */ }
 #sidebar { width: 250px; background-color: #20262d; padding: 15px; border-right: 1px solid #3f4c5a; display: flex; flex-direction: column; gap: 10px; }
 .sidebar-section { margin-bottom: 20px; border-top: 1px solid #3f4c5a; padding-top: 10px; }
 .sidebar-section h3, .sidebar-section h4 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -60,6 +60,17 @@
                     </div>
                 </div>
             </div>
+            <div class="sidebar-section">
+                <h3>Audio Controls</h3>
+                <div id="audio-controls" style="display: flex; flex-direction: column; gap: 10px;">
+                    <select id="audio-input-select" style="width: 100%; padding: 8px; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0; border-radius: 4px;"></select>
+                    <div style="display: flex; gap: 10px;">
+                        <button id="record-button" style="flex-grow: 1;">Record</button>
+                        <button id="test-audio-button" style="flex-grow: 1;">Test Audio</button>
+                    </div>
+                    <audio id="test-audio-playback" controls style="display: none; width: 100%;"></audio>
+                </div>
+            </div>
              <div class="sidebar-section">
                 <h3>Player View</h3>
                 <button id="open-player-view-button">Open Player View</button>
@@ -353,6 +364,10 @@
                 <div class="save-option">
                     <input type="checkbox" id="save-timer-checkbox" name="timer" value="timer" checked>
                     <label for="save-timer-checkbox">Campaign Timer</label>
+                </div>
+                <div class="save-option">
+                    <input type="checkbox" id="save-audio-checkbox" name="audio" value="audio" checked>
+                    <label for="save-audio-checkbox">Audio Recordings</label>
                 </div>
             </div>
             <div id="save-conflict-warnings" style="color: yellow; margin-top: 10px;"></div>


### PR DESCRIPTION
This commit introduces a new audio recording feature and fixes a CSS bug where the footer was overlapping content.

The audio recording feature includes:
- A new UI section with controls for recording, testing, and selecting audio input devices.
- Logic to automatically start and stop recording with the campaign timer.
- Integration with the save/load functionality, ensuring that audio files are included in the campaign data and that older save files without audio can still be loaded.

The footer fix adds padding to the bottom of the body to prevent the fixed footer from obscuring the content at the bottom of the page.