### PR TITLE
fix: Rearrange footer content for better layout

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -305,17 +305,19 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 }
 
 #footer-left {
-    flex-basis: 50%;
+    flex-basis: 30%;
 }
 
 #footer-center {
-    flex-basis: 50%;
+    flex-basis: 60%;
 }
 
 #dm-tools-list {
     list-style: none;
     padding: 0;
-    margin: 0;
+    margin: 10px 0 0 0;
+    display: flex;
+    gap: 10px;
 }
 
 #dm-tools-list li {
@@ -323,9 +325,9 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     background-color: #3a4f6a;
     color: #e0e0e0;
     border-radius: 4px;
-    margin-bottom: 5px;
     cursor: pointer;
     text-align: center;
+    flex-grow: 1;
 }
 
 #dm-tools-list li:hover {

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -431,12 +431,6 @@
     <footer id="dm-floating-footer">
         <div id="footer-content-wrapper">
             <div id="footer-left">
-                <h3>DM Tools</h3>
-                <ul id="dm-tools-list">
-                    <li data-action="open-initiative-tracker">Initiative Tracker</li>
-                    <li data-action="open-dice-roller">Dice Roller</li>
-                    <li data-action="open-action-log">Action Log</li>
-                </ul>
                 <h3 style="margin-top: 15px;">Campaign Controls</h3>
                 <div id="footer-timer-audio-area">
                     <div id="footer-timer-area">
@@ -458,6 +452,12 @@
                 <div id="footer-notes-area">
                     <input type="text" id="dm-notes-input" placeholder="Type a quick note and press Enter...">
                 </div>
+                <h3 style="margin-top: 15px;">DM Tools</h3>
+                <ul id="dm-tools-list">
+                    <li data-action="open-initiative-tracker">Initiative Tracker</li>
+                    <li data-action="open-dice-roller">Dice Roller</li>
+                    <li data-action="open-action-log">Action Log</li>
+                </ul>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
This commit rearranges the content within the floating footer to provide a more intuitive layout and better use of space.

The 'DM Tools' list has been moved from the left column to the center column, below the notes input. The flexbox properties of the footer columns have been adjusted to create a more balanced layout. This addresses the feedback of placing the DM tools to the right of the campaign controls and provides a more logical grouping of elements in the footer.