### PR TITLE
feat: Implement UI improvements

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -61,6 +61,10 @@ button:hover, input[type="file"]:hover {
     background-color: #a0b4c9;
 }
 
+#map-tools-section {
+    display: none;
+}
+
 /* Styling for buttons in the map tools section */
 #map-tools-section .map-tools-buttons button {
     display: block; /* Stack buttons vertically */
@@ -994,6 +998,10 @@ input:checked + .slider:before {
     text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.7); /* Shadow for all text */
     display: flex;
     flex-direction: column;
+}
+
+#dice-roller-overlay {
+    z-index: 1003;
 }
 
 #dice-roller-overlay .overlay-content,

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -148,6 +148,16 @@
         </ul>
     </div>
 
+    <div id="map-tools-context-menu" class="context-menu" style="display: none; position: absolute;">
+        <ul>
+            <li data-action="link-child-map">Link to Child Map</li>
+            <li data-action="link-note">Link Note</li>
+            <li data-action="link-character">Link Character</li>
+            <li data-action="link-trigger">Link Trigger</li>
+            <li data-action="remove-links">Remove Links</li>
+        </ul>
+    </div>
+
     <div id="character-context-menu" class="context-menu" style="display: none; position: absolute;">
         <ul>
             <li data-action="link-to-character">Link to Character</li>


### PR DESCRIPTION
This commit introduces three UI improvements to the DnDemicube DM view:

1.  The dice roller overlay now has a higher z-index to ensure it appears above the initiative tracker.
2.  The map tools sidebar has been converted into a right-click context menu that only appears on the map in edit mode.
3.  The character card overlay for initiative tokens is now triggered by a right-click instead of a left-click, allowing for easier dragging of tokens.