### PR TITLE
Fix bugs with note/character linking and map desync

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -319,6 +319,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const ctx = dmCanvas.getContext('2d');
         const img = new Image();
         img.onload = () => {
+            if (fileName !== selectedMapFileName) {
+                console.log(`Map draw for ${fileName} cancelled; ${selectedMapFileName} is now selected.`);
+                return;
+            }
             ctx.clearRect(0, 0, dmCanvas.width, dmCanvas.height);
 
             const hRatio = dmCanvas.width / img.width;
@@ -3821,6 +3825,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 sendMapToPlayerView(parentMapName);
                             }
                         }
+                        selectedNoteForContextMenu = null;
                         break;
                 }
             }
@@ -4494,6 +4499,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 sendMapToPlayerView(parentMapName);
                             }
                         }
+                        selectedCharacterForContextMenu = null;
                         break;
                 }
             }


### PR DESCRIPTION
This commit addresses two bugs in the DM view:

1.  **Incorrect Re-linking:** Toggling the visibility of a linked note or character icon from the map would leave the application in a "re-linking" state. Clicking a note or character from the sidebar would then incorrectly trigger a re-link. This was fixed by resetting the `selectedNoteForContextMenu` and `selectedCharacterForContextMenu` variables to null after the visibility toggle action is performed.

2.  **Map Desynchronization:** Switching between maps or view/edit modes too quickly could cause a race condition, leading to the wrong map or an incorrect state being displayed. This was fixed by adding a check within the `displayMapOnCanvas` function's image loading callback. The check ensures that the map being drawn is still the currently selected map before rendering it to the canvas.