### PR TITLE
Fix slideshow race condition in player view

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -17,13 +17,28 @@ const authorText = document.getElementById('author-text');
 let slideshowActive = false;
 let currentSlideIndex = 0;
 let shuffledCharacters = [];
-let quoteMap = null;
-
-fetch('quote_map.json')
-    .then(response => response.json())
-    .then(data => {
-        quoteMap = data;
+const quoteMapPromise = fetch('quote_map.json')
+    .then(response => {
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+    })
+    .catch(e => {
+        console.error("Failed to load quote_map.json:", e);
+        // Return a default/empty quote map to prevent further errors
+        return {
+            "ability_scores": {},
+            "character_details": {},
+            "combat_stats": {},
+            "roleplaying_details": {}
+        };
     });
+
+let quoteMap = null;
+quoteMapPromise.then(data => {
+    quoteMap = data;
+});
 
 function getRandomStat(character) {
     if (!quoteMap) return null;
@@ -369,16 +384,18 @@ window.addEventListener('message', (event) => {
                 break;
             case 'clearMap':
                 console.log("Player view received clearMap message.");
-                currentMapImage = null;
-                currentOverlays = [];
+                quoteMapPromise.then(() => {
+                    currentMapImage = null;
+                    currentOverlays = [];
 
-                shuffledCharacters = data.characters.sort(() => 0.5 - Math.random());
-                currentSlideIndex = 0;
+                    shuffledCharacters = data.characters.sort(() => 0.5 - Math.random());
+                    currentSlideIndex = 0;
 
-                playerMapContainer.style.display = 'none';
-                slideshowContainer.style.display = 'flex';
-                slideshowActive = true;
-                animateSlideshow();
+                    playerMapContainer.style.display = 'none';
+                    slideshowContainer.style.display = 'flex';
+                    slideshowActive = true;
+                    animateSlideshow();
+                });
                 break;
             case 'showNotePreview':
                 const notePreviewOverlay = document.getElementById('note-preview-overlay');


### PR DESCRIPTION
The slideshow in the player view was not playing because of a race condition. The code was attempting to start the slideshow before the necessary `quote_map.json` file was loaded, causing the slideshow to fail silently.

This change refactors the `player_view.js` file to use a Promise to handle the loading of `quote_map.json`. The slideshow is now only initiated after the promise is resolved, ensuring that the quote data is available. Error handling for the fetch operation has also been added to make the code more robust.