### PR TITLE
Fix multiple errors causing slideshow failure

### DIFF
--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -205,7 +205,11 @@
 </head>
 <body>
     <div id="slideshow-container" class="relative w-full h-screen flex items-center justify-center overflow-hidden bg-black" style="display: none;">
-        <!-- ... slideshow content ... -->
+    <div id="content-container" class="text-center text-white p-8">
+        <img id="portrait-img" src="" alt="Character Portrait" class="mx-auto mb-4 w-48 h-48 rounded-full object-cover border-4 border-gray-700">
+        <p id="quote-text" class="text-3xl italic quote-font mb-4">"</p>
+        <p id="author-text" class="text-xl font-bold"></p>
+    </div>
     </div>
     <div id="player-map-container">
         <canvas id="player-canvas"></canvas>


### PR DESCRIPTION
This commit addresses two critical errors that were preventing the player view slideshow from functioning:

1.  A syntax error in `quote_map.json` was preventing it from being parsed correctly. The file has been re-written to ensure it is valid JSON.
2.  A `TypeError` was occurring because a necessary HTML element with id `content-container` was missing from `player_view.html`. This element has been added.

These fixes, combined with the previous commit that addressed the race condition, should resolve the slideshow issues.