### PR TITLE
Refactor slideshow logic and add default portraits

### DIFF
--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -206,7 +206,10 @@
 <body>
     <div id="slideshow-container" class="relative w-full h-screen flex items-center justify-center overflow-hidden bg-black" style="display: none;">
     <div id="content-container" class="text-center text-white p-8">
-        <img id="portrait-img" src="" alt="Character Portrait" class="mx-auto mb-4 w-48 h-48 rounded-full object-cover border-4 border-gray-700">
+    <div class="mx-auto mb-4 w-48 h-48 rounded-full border-4 border-gray-700 relative">
+        <img id="portrait-img" src="" alt="Character Portrait" class="w-full h-full rounded-full object-cover">
+        <div id="portrait-initials" class="w-full h-full rounded-full bg-gray-600 flex items-center justify-center text-5xl font-bold text-white absolute top-0 left-0" style="display: none;"></div>
+    </div>
         <p id="quote-text" class="text-3xl italic quote-font mb-4">"</p>
         <p id="author-text" class="text-xl font-bold"></p>
     </div>


### PR DESCRIPTION
This commit introduces a major refactor of the slideshow functionality to improve reliability and add new features.

- The slideshow content is now generated as a "playlist" by the DM view and sent to the player view. This fixes bugs where the slideshow would stop randomly or show incorrect quotes.
- A communication channel from the player view back to the DM view has been added to handle pausing and resuming the slideshow playlist.
- If a character does not have a profile photo, a placeholder with their initials is now displayed, similar to the initiative tokens.