### PR TITLE
Refactor slideshow logic and fix stat issues

### DIFF
--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -231,6 +231,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             });
+
+            for (const attr in modifiers) {
+                sheetData[`${attr}_modifier`] = modifiers[attr].textContent;
+            }
+
             if (portraitPreview.style.display !== 'none') {
                 sheetData['character_portrait'] = portraitPreview.src;
             }

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -345,16 +345,14 @@ document.addEventListener('DOMContentLoaded', () => {
             'hit_points': ['hp_current', 'hp_max']
         };
 
-        const prioritizedStats = [
+        const allStats = [
             ...Object.keys(quoteMap.ability_scores),
-            ...Object.keys(quoteMap.combat_stats)
-        ];
-        const otherStats = [
+            ...Object.keys(quoteMap.combat_stats),
             ...Object.keys(quoteMap.character_details).filter(stat => stat !== 'alignment'),
             ...Object.keys(quoteMap.roleplaying_details)
         ];
 
-        let commonStats = prioritizedStats.filter(stat => {
+        let commonStats = allStats.filter(stat => {
             return charactersData.every(character => {
                 if (!character.sheetData) return false;
                 const key = statKeyMap[stat] || stat;
@@ -364,13 +362,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 return character.sheetData[key] !== undefined && character.sheetData[key] !== '';
             });
         });
-
-        if (commonStats.length === 0) {
-            console.log("No common prioritized stats found. Checking other stats.");
-            commonStats = otherStats.filter(stat =>
-                charactersData.every(character => character.sheetData && (character.sheetData[stat] !== undefined && character.sheetData[stat] !== ''))
-            );
-        }
 
         if (commonStats.length === 0) {
             console.warn("No common stats found for all characters to generate a themed slideshow.");


### PR DESCRIPTION
This commit addresses several issues with the slideshow and character stat handling:

1.  **Removes Stat Priority:** The distinction between 'prioritized' and 'other' stats has been removed. The slideshow now pulls from a unified list of all common stats, increasing quote variety.
2.  **Fixes '(undefined)' Modifier Bug:** Modifiers for ability scores were not being saved with the character sheet data, causing them to appear as 'undefined' in slideshow quotes. `character_sheet.js` has been updated to include these modifiers in the saved data.
3.  **Fixes Stat-Checking Logic:** The `generateSlideshowPlaylist` function in `dm_view.js` now uses a `statKeyMap` to correctly identify common stats, resolving an issue where it would fail to find them due to key mismatches between `quote_map.json` and the character sheet data.