### PR TITLE
Fix: Correct Story Beats canvas sizing

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6393,6 +6393,11 @@ function displayToast(messageElement) {
             return;
         }
 
+        const container = storyTreeContainer;
+        const canvas = storyTreeCanvas;
+        canvas.width = container.clientWidth;
+        canvas.height = container.clientHeight;
+
         storyTreeCanvasObj = new fabric.Canvas(storyTreeCanvas);
 
         const startNode = new fabric.Rect({


### PR DESCRIPTION
This change fixes a bug where the Fabric.js canvas in the 'Story Beats' tab was not sized correctly. The `initStoryTree` function in `dm_view.js` is updated to programmatically set the canvas element's width and height to match its container's dimensions before Fabric.js initializes on it. This ensures the interactive canvas layer (`upper-canvas`) is created with the correct size, resolving the UI issue.