### PR TITLE
feat: Implement new story beats canvas

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -23,23 +23,105 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
     overflow: hidden;
     padding: 10px;
 }
-#map-container.hidden, #story-tree-container.hidden {
+#map-container.hidden, .canvas-container.hidden {
     display: none !important;
 }
 
-#story-tree-container {
-    flex-grow: 1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+.canvas-container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    cursor: grab;
     overflow: hidden;
-    padding: 10px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    touch-action: none; /* Prevent browser touch gestures */
 }
 
-#story-tree-canvas {
-    max-width: 100%;
-    max-height: 100%;
-    border: 1px solid #3f4c5a;
+#quest-canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background-color: #f9f9f9;
+}
+
+.card-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none; /* Allow events to pass through to the canvas */
+}
+
+.card {
+    background-color: #ffffff;
+    border: 2px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    position: absolute;
+    width: 250px;
+    text-align: center;
+    pointer-events: auto; /* Re-enable pointer events for the cards */
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    transform-origin: center center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.card:hover {
+    transform: scale(1.05);
+    border-color: #93c5fd;
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.15);
+}
+
+.card.selected {
+    border-color: #3b82f6;
+    transform: scale(1.08);
+    box-shadow: 0 8px 20px rgba(59, 130, 246, 0.2);
+    z-index: 10;
+}
+
+.card h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1f2937;
+    word-break: break-all;
+}
+
+.context-menu {
+    position: absolute;
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    list-style: none;
+    padding: 8px 0;
+    margin: 0;
+    z-index: 200;
+    min-width: 150px;
+    cursor: pointer;
+}
+
+.context-menu li {
+    padding: 10px 15px;
+    font-size: 0.9rem;
+    color: #1f2937;
+    transition: background-color 0.1s ease;
+}
+
+.context-menu li:hover {
+    background-color: #f1f5f9;
+}
+
+/* Mode-specific cursors */
+body.moving-mode {
+    cursor: grabbing;
 }
 
 /* #note-editor-container has initial inline styles: display: none; flex-grow: 1; padding: 10px; */

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -103,8 +103,9 @@
         <canvas id="dm-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
     </div>
-    <div id="story-tree-container" style="display: none; flex-grow: 1; padding: 10px;">
-        <canvas id="story-tree-canvas"></canvas>
+    <div class="canvas-container" id="canvas-container" style="display: none; flex-grow: 1;">
+        <canvas id="quest-canvas"></canvas>
+        <div class="card-container" id="card-container"></div>
     </div>
     <div id="note-editor-container" style="display: none; flex-grow: 1; padding: 10px;">
         <div id="note-editor-area" style="display: flex; flex-direction: column; height: 100%;">


### PR DESCRIPTION
Replaces the existing fabric.js-based story beats canvas with a new implementation based on the provided HTML/CSS/JS example.

The new implementation features a card-based system for quests, with the following features:
- Add, rename, and delete quest cards via a context menu.
- Move quest cards by dragging them on the canvas.
- Pan and zoom the canvas to navigate the story tree.
- Connections are drawn between parent and child quests.

The save and load functionality has been updated to support the new `quests` data structure. A check has been added to the load function to detect and warn the user about the old data format, ensuring that previous versions of save files can be loaded without breaking the application.