### PR TITLE
feat: Add story beat card overlay

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -383,6 +383,121 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.story-beat-card-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1002;
+}
+
+.story-beat-card-content {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 350px;
+    max-height: calc(100% - 20px);
+    background-color: #fcfcf8;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.story-beat-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+    border-bottom: 1px solid #e9e8ce;
+}
+
+.story-beat-card-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: #1c1c0d;
+}
+
+.story-beat-card-back-button,
+.story-beat-card-close-button {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: #1c1c0d;
+    padding: 0 5px;
+}
+
+#story-beat-card-body {
+    padding: 20px;
+    font-family: "Spline Sans", "Noto Sans", sans-serif;
+    color: #1c1c0d;
+}
+
+#story-beat-card-body h1 {
+    font-size: 22px;
+    font-weight: bold;
+    margin-bottom: 1rem;
+}
+
+#story-beat-card-body h3 {
+    font-size: 18px;
+    font-weight: bold;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+#story-beat-card-body p {
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+#story-beat-card-body .status-tabs {
+    display: flex;
+    background-color: #f4f4e6;
+    border-radius: 8px;
+    padding: 5px;
+    margin-bottom: 1rem;
+}
+
+#story-beat-card-body .status-tab {
+    flex-grow: 1;
+    text-align: center;
+    padding: 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #9e9d47;
+    font-weight: 500;
+}
+
+#story-beat-card-body .status-tab.active {
+    background-color: #fcfcf8;
+    box-shadow: 0 0 4px rgba(0,0,0,0.1);
+    color: #1c1c0d;
+}
+
+#story-beat-card-body .prerequisite,
+#story-beat-card-body .reward-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 0;
+}
+
+@media (max-width: 600px) {
+    .story-beat-card-content {
+        width: calc(100% - 20px);
+        max-width: 350px;
+    }
+}
+
 /* New Floating Footer Styles */
 #dm-floating-footer {
     position: fixed;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -204,6 +204,17 @@
         </div>
     </div>
 
+    <div id="story-beat-card-overlay" class="story-beat-card-overlay" style="display: none;">
+        <div class="story-beat-card-content">
+            <div class="story-beat-card-header">
+                <button id="story-beat-card-back-button" class="story-beat-card-back-button">←</button>
+                <h2>Quest Details</h2>
+                <button id="story-beat-card-close-button" class="story-beat-card-close-button">&times;</button>
+            </div>
+            <div id="story-beat-card-body"></div>
+        </div>
+    </div>
+
     <div id="json-modal" class="modal" style="display: none;">
         <div class="modal-content">
             <span class="close-button" id="json-modal-close-button">&times;</span>


### PR DESCRIPTION
This commit introduces a new feature to the 'Story Beats' tab: a clickable overlay for quest cards.

When a user clicks on a quest card in the story tree, an overlay appears in the top right corner of the screen, displaying detailed information about the quest. This includes the quest's name, status (active, abandon, completed), a description, prerequisites, and rewards.

The overlay is styled to match the provided HTML example and includes a header with a back button and a close button. The overlay can be closed by clicking either of these buttons, clicking the same quest card again, or clicking outside the overlay.

The implementation ensures backward compatibility with older save files by adding default values for the new quest properties (`description`, `status`, `prerequisites`, `rewards`, `recommendations`, and `completionSteps`).