### PR TITLE
Fix: Correct Story Beat Card Drag-and-Drop Functionality

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6829,10 +6829,12 @@ function displayToast(messageElement) {
                 {
                     label: 'Move',
                     action: () => {
-                        isMoving = true;
-                        document.body.classList.add('moving-mode');
-                        const quest = quests.find(q => q.id === questId);
-                        const cardElement = document.querySelector(`.card[data-id="${questId}"]`);
+                        setTimeout(() => {
+                            isMoving = true;
+                            document.body.classList.add('moving-mode');
+                            const quest = quests.find(q => q.id === questId);
+                            const cardElement = document.querySelector(`.card[data-id="${questId}"]`);
+                        }, 0);
                     }
                 },
                 {


### PR DESCRIPTION
The "move" functionality for story beat cards was broken due to a race condition in the event handling. The `mouseup` event from the context menu click was firing before the 'move' state was properly set, causing the move mode to be immediately cancelled.

This commit fixes the issue by wrapping the 'move' action logic in a `setTimeout` with a zero-second delay. This defers the execution of the code until after the current event loop, ensuring that the move state is set correctly and allowing the drag-and-drop functionality to work as intended.