### PR TITLE
feat: Rework story beats quest tree canvas

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -383,6 +383,23 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.story-beat-card {
+    position: absolute;
+    background-color: #2a3a4a;
+    border: 1px solid #4a5f7a;
+    border-radius: 8px;
+    padding: 15px;
+    color: #e0e0e0;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+    text-align: center;
+}
+
+.story-beat-card.final-quest {
+    background-color: #4a3a2a;
+    border-color: #7a5f4a;
+}
+
 .story-beat-card-overlay {
     position: fixed;
     top: 0;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -156,7 +156,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.10.377/pdf.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js"></script>
     <script src="dm_view.js"></script>
     <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 


### PR DESCRIPTION
This commit completely reworks the story beats quest tree canvas. The previous implementation using fabric.js was buggy and has been replaced with a new implementation from scratch using the native HTML5 Canvas API.

The new implementation includes:
- A canvas for drawing connections between quests.
- HTML `div` elements for quest cards, positioned over the canvas.
- Panning and zooming functionality.
- Right-click context menus for adding, renaming, deleting, and linking quests.
- A "Final Quest" that is centered by default and cannot be deleted.
- The `fabric.js` dependency has been removed.
- Save and load functionality has been updated to support the new data structure, while maintaining backward compatibility for old save files (by showing a warning and resetting the tree).