### PR TITLE
feat: Rework story beats quest tree canvas

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -1,4 +1,5 @@
-body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; background-color: #15191e; color: #e0e0e0; padding-bottom: 60px; /* Added to prevent footer overlap */ }
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
+body { margin: 0; font-family: 'Inter', sans-serif; display: flex; height: 100vh; background-color: #15191e; color: #e0e0e0; padding-bottom: 60px; /* Added to prevent footer overlap */ }
 #sidebar { width: 250px; background-color: #20262d; padding: 15px; border-right: 1px solid #3f4c5a; display: flex; flex-direction: column; gap: 10px; }
 .sidebar-section { margin-bottom: 20px; border-top: 1px solid #3f4c5a; padding-top: 10px; }
 .sidebar-section h3, .sidebar-section h4 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
@@ -38,11 +39,11 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
     touch-action: none; /* Prevent browser touch gestures */
 }
 
-#quest-canvas {
+#quest-canvas { /* Using ID for specificity */
     display: block;
     width: 100%;
     height: 100%;
-    background-color: #2a3138;
+    background-color: #2a3138; /* Dark background */
 }
 
 .card-container {
@@ -55,11 +56,11 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
 }
 
 .card {
-    background-color: #ffffff;
-    border: 2px solid #e2e8f0;
+    background-color: #3a4f6a; /* Dark card background */
+    border: 2px solid #5f6a7a; /* Border color */
     border-radius: 10px;
     padding: 1.25rem 1.5rem;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     position: absolute;
     width: 250px;
     text-align: center;
@@ -71,18 +72,19 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    color: #e0e0e0; /* Light text */
 }
 
 .card:hover {
     transform: scale(1.05);
-    border-color: #93c5fd;
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.15);
+    border-color: #b6cae1; /* Highlight border on hover */
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.3);
 }
 
 .card.selected {
-    border-color: #3b82f6;
+    border-color: #8ab4f8; /* A brighter selection color */
     transform: scale(1.08);
-    box-shadow: 0 8px 20px rgba(59, 130, 246, 0.2);
+    box-shadow: 0 8px 20px rgba(138, 180, 248, 0.2);
     z-index: 10;
 }
 
@@ -90,16 +92,16 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
     margin: 0;
     font-size: 1.25rem;
     font-weight: 600;
-    color: #1f2937;
+    color: #e0e0e0; /* Light text for heading */
     word-break: break-all;
 }
 
 .context-menu {
     position: absolute;
-    background-color: #2a3138;
+    background-color: #20262d; /* Dark context menu */
     border: 1px solid #3f4c5a;
     border-radius: 8px;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
     list-style: none;
     padding: 8px 0;
     margin: 0;
@@ -111,15 +113,19 @@ body { margin: 0; font-family: sans-serif; display: flex; height: 100vh; backgro
 .context-menu li {
     padding: 10px 15px;
     font-size: 0.9rem;
-    color: #e0e0e0;
+    color: #e0e0e0; /* Light text */
     transition: background-color 0.1s ease;
 }
 
 .context-menu li:hover {
-    background-color: #3f4c5a;
+    background-color: #3f4c5a; /* Hover color */
 }
 
 /* Mode-specific cursors */
+body.linking-mode {
+    cursor: crosshair;
+}
+
 body.moving-mode {
     cursor: grabbing;
 }
@@ -383,22 +389,6 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
-.story-beat-card {
-    position: absolute;
-    background-color: #2a3a4a;
-    border: 1px solid #4a5f7a;
-    border-radius: 8px;
-    padding: 15px;
-    color: #e0e0e0;
-    cursor: pointer;
-    box-shadow: 0 4px 8px rgba(0,0,0,0.3);
-    text-align: center;
-}
-
-.story-beat-card.final-quest {
-    background-color: #4a3a2a;
-    border-color: #7a5f4a;
-}
 
 .story-beat-card-overlay {
     position: fixed;


### PR DESCRIPTION
Reworks the story beats quest tree from scratch to fix issues with card linking and movement.

- Replaces the old implementation with a new interactive canvas featuring pan, zoom, and card dragging.
- Implements a right-click context menu on the canvas to add new quests.
- Adds a context menu to quest cards for renaming, deleting, linking, and moving.
- The "Final Quest" is now present by default and cannot be deleted.
- Integrates the existing quest details overlay with the new system.
- Adapts all new styles to the application's dark theme for a consistent look and feel.
- Ensures the new data structure is compatible with the campaign save and load functionality.