### PR TITLE
Feat: Expand Quest Data Model and Update Story Beat Overlay

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -389,6 +389,74 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* New Story Beat Card Overlay Styles */
+.quest-card-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+.quest-card-column h3 {
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 5px;
+    margin-top: 15px;
+}
+
+.editable-div, .editable-textarea {
+    border: 1px solid #ccc;
+    padding: 5px;
+    min-height: 50px;
+    border-radius: 4px;
+    background-color: #fff;
+}
+
+.editable-textarea {
+    width: 95%;
+}
+
+#quest-status, #quest-type, #quest-associated-maps {
+    width: 100%;
+    padding: 5px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+}
+
+#quest-associated-maps {
+    height: 100px;
+}
+
+.npc-row {
+    display: flex;
+    gap: 5px;
+    margin-bottom: 5px;
+    align-items: center;
+}
+
+.npc-select, .npc-role {
+    flex-grow: 1;
+    padding: 5px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+}
+
+.remove-npc-btn, #add-npc-btn {
+    padding: 5px 10px;
+}
+
+.rewards-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px;
+    align-items: center;
+}
+
+#save-quest-details-btn {
+    width: 100%;
+    margin-top: 20px;
+    padding: 10px;
+    font-size: 16px;
+}
+
 
 .story-beat-card-overlay {
     position: fixed;


### PR DESCRIPTION
This commit introduces a more robust data model for quests in the Story Beats section of the DnDemicube project.

The following fields have been added to the quest data structure:
- Quest Status
- Quest Type
- Starting Triggers
- Associated Maps
- Associated NPCs
- Failure Triggers
- Success Triggers
- Detailed Rewards (XP, Loot, Magic Items, Information)

The Story Beat Card overlay has been redesigned to allow DMs to view and edit this new, detailed information.

Backward compatibility has been implemented in the campaign loading functionality to ensure that older save files can still be loaded without issues. The new fields are added with default values when an older save is detected.