### PR TITLE
Feat: Enhance Story Beat Overlay with Duration, Difficulty, and Steps

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -451,6 +451,36 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     font-size: 16px;
 }
 
+/* New Story Steps & Difficulty Styles */
+.difficulty-rating {
+    cursor: pointer;
+}
+
+.star {
+    font-size: 24px;
+    color: #f5b32d;
+}
+
+.story-step-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 5px;
+}
+
+.story-step-checkbox {
+    width: 20px;
+    height: 20px;
+}
+
+.story-step-text {
+    flex-grow: 1;
+}
+
+.remove-step-btn {
+    padding: 5px 10px;
+}
+
 
 .story-beat-card-overlay {
     position: fixed;


### PR DESCRIPTION
This commit adds several new features to the story beat card overlay, based on user feedback.

The following fields and features have been added:
- An editable 'Story Duration' text field.
- A 5-star 'Difficulty' rating system.
- A dynamic 'Story Steps' section, allowing DMs to add, edit, and mark individual quest steps as complete.

The quest data model has been updated to support these new features, and backward compatibility for loading older save files has been maintained. The CSS has also been updated to style the new UI elements.