### PR TITLE
feat: Redesign story beat cards and add export functionality

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -474,6 +474,69 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* JSON Export Modal Styles */
+#json-export-overlay {
+    /* This will use the .modal class, but we can override if needed */
+    /* For now, we assume .modal provides the basic overlay */
+}
+
+#json-export-content-container {
+    background-color: #2a3138;
+    padding: 20px;
+    border: 1px solid #3f4c5a;
+    border-radius: 8px;
+    width: 80%;
+    max-width: 600px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+#json-export-close-button {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: none;
+    border: none;
+    color: #e0e0e0;
+    font-size: 24px;
+    font-weight: bold;
+    cursor: pointer;
+    line-height: 1;
+}
+
+#json-export-close-button:hover {
+    color: #b6cae1;
+}
+
+#json-export-content-container h3 {
+    margin-top: 0;
+    border-bottom: 1px solid #3f4c5a;
+    padding-bottom: 10px;
+}
+
+#json-export-content {
+    background-color: #15191e; /* Darker background for the code */
+    color: #d4d4d4;
+    padding: 15px;
+    border: 1px solid #3f4c5a;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    flex-grow: 1; /* Allow the pre tag to fill available space */
+    overflow-y: auto; /* Add scrollbar if content overflows */
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 14px;
+}
+
+#copy-json-button {
+    margin-top: 15px;
+    padding: 10px;
+    align-self: center; /* Center the button */
+    width: 50%;
+}
+
 .trigger-row {
     display: flex;
     align-items: center;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -216,7 +216,7 @@
             <div class="story-beat-card-header">
                 <button id="story-beat-card-back-button" class="story-beat-card-back-button">←</button>
                 <h2>Quest Details</h2>
-                <button id="story-beat-card-close-button" class="story-beat-card-close-button">&times;</button>
+                <button id="story-beat-card-export-button" class="story-beat-card-close-button" title="Export Quest to JSON">📤</button>
             </div>
             <div id="story-beat-card-body"></div>
         </div>
@@ -511,5 +511,14 @@
             </div>
         </div>
     </footer>
+
+    <div id="json-export-overlay" class="modal" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button" id="json-export-close-button">&times;</span>
+            <h3>Quest JSON Data</h3>
+            <pre id="json-export-content" style="white-space: pre-wrap; word-wrap: break-word; background-color: #1e1e1e; color: #d4d4d4; padding: 10px; border: 1px solid #3f4c5a;"></pre>
+            <button id="copy-json-button" style="margin-top: 10px;">Copy to Clipboard</button>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a complete visual overhaul of the story beat cards on the story tree canvas. It also adds several new features based on user feedback, including a new UI for managing triggers and the ability to export quest data to JSON.

Key changes:

- **Card Visuals (`dm_view.css`, `dm_view.js`):**
  - Cards are now larger (300x300px) and square.
  - A two-layer design has been implemented, with a background layer displaying associated map images and a semi-transparent grey overlay for text content.
  - The text layout on the card has been updated to include a title, story duration, a 5-star difficulty rating, linked character profile icons, a description, and a rewards summary.

- **Dynamic Font Sizing (`dm_view.js`):**
  - To prevent text overflow on the redesigned cards, a JavaScript function has been added that dynamically reduces the font size of the description and rewards sections until they fit within the card's boundaries.

- **Trigger Input UI (`dm_view.js`, `dm_view.css`):**
  - The `<textarea>` inputs for Starting, Success, and Failure triggers in the quest details editor have been replaced with a dynamic list UI.
  - Users can now add and remove individual trigger fields, offering a more structured editing experience.

- **JSON Export (`dm_view.html`, `dm_view.js`, `dm_view.css`):**
  - The close button on the quest details overlay has been replaced with an "Export" icon.
  - Clicking this icon opens a new modal displaying the full data for the current quest as a formatted JSON string.
  - The modal includes a "Copy to Clipboard" button for convenience.
  - The new modal has been styled to be consistent with the application's UI.

- **Bug Fixes (`dm_view.js`):**
  - Fixed a state management bug where closing the quest details overlay would not properly reset the active quest ID, which could cause the export function to act on the wrong quest.