### PR TITLE
fix: Correct variable scope for export button

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7245,15 +7245,8 @@ function displayToast(messageElement) {
         });
     }
 
-    // Initial setup
-    resizeCanvas(); // Set initial canvas size
-    drawConnections();
-    renderCards();
-    }
-
     if (storyBeatCardExportButton) {
         storyBeatCardExportButton.addEventListener('click', () => {
-            // This relies on activeOverlayCardId being set correctly inside the initStoryTree function scope
             const quest = quests.find(q => q.id === activeOverlayCardId);
             if (quest) {
                 const exportQuest = {
@@ -7282,6 +7275,13 @@ function displayToast(messageElement) {
             }
         });
     }
+
+    // Initial setup
+    resizeCanvas(); // Set initial canvas size
+    drawConnections();
+    renderCards();
+    }
+
 
     if (jsonExportCloseButton) {
         jsonExportCloseButton.addEventListener('click', () => {


### PR DESCRIPTION
The `activeOverlayCardId` variable was defined within the `initStoryTree` function, but the event listener for the `storyBeatCardExportButton` was in the global scope, leading to a `ReferenceError`.

This commit moves the event listener for the export button inside the `initStoryTree` function, giving it access to the necessary variable and fixing the bug.