### PR TITLE
feat: Implement JSON editing for Story Beats

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -515,9 +515,12 @@
     <div id="json-export-overlay" class="modal" style="display: none;">
         <div class="modal-content">
             <span class="close-button" id="json-export-close-button">&times;</span>
-            <h3>Quest JSON Data</h3>
-            <pre id="json-export-content" style="white-space: pre-wrap; word-wrap: break-word; background-color: #1e1e1e; color: #d4d4d4; padding: 10px; border: 1px solid #3f4c5a;"></pre>
-            <button id="copy-json-button" style="margin-top: 10px;">Copy to Clipboard</button>
+            <h3>View/Edit Quest JSON</h3>
+            <textarea id="json-edit-content" style="width: 95%; height: 400px; font-family: monospace; background-color: #1e1e1e; color: #d4d4d4; border: 1px solid #3f4c5a;"></textarea>
+            <div style="margin-top: 10px;">
+                <button id="save-json-button">Save</button>
+                <button id="copy-json-button">Copy to Clipboard</button>
+            </div>
         </div>
     </div>
 </body>

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -168,10 +168,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const storyBeatCardExportButton = document.getElementById('story-beat-card-export-button');
     const storyBeatCardBody = document.getElementById('story-beat-card-body');
     const quoteEditorContainer = document.getElementById('quote-editor-container');
-    const jsonExportOverlay = document.getElementById('json-export-overlay');
-    const jsonExportContent = document.getElementById('json-export-content');
-    const jsonExportCloseButton = document.getElementById('json-export-close-button');
+    const jsonEditOverlay = document.getElementById('json-export-overlay'); // Changed name
+    const jsonEditContent = document.getElementById('json-edit-content'); // Changed name
+    const jsonEditCloseButton = document.getElementById('json-export-close-button'); // Changed name
     const copyJsonButton = document.getElementById('copy-json-button');
+    const saveJsonButton = document.getElementById('save-json-button'); // New button
     const saveQuotesButton = document.getElementById('save-quotes-button');
     const quoteJsonEditor = document.getElementById('quote-json-editor');
 
@@ -7268,8 +7269,8 @@ function displayToast(messageElement) {
                     difficulty: quest.difficulty || 0,
                     storySteps: quest.storySteps || [],
                 };
-                jsonExportContent.textContent = JSON.stringify(exportQuest, null, 2);
-                jsonExportOverlay.style.display = 'flex';
+                jsonEditContent.value = JSON.stringify(exportQuest, null, 2); // Use value for textarea
+                jsonEditOverlay.style.display = 'flex';
             } else {
                 alert("Could not find quest data to export. Please reopen the quest card and try again.");
             }
@@ -7282,16 +7283,47 @@ function displayToast(messageElement) {
     renderCards();
     }
 
+    if (saveJsonButton) {
+        saveJsonButton.addEventListener('click', () => {
+            try {
+                const updatedQuestData = JSON.parse(jsonEditContent.value);
+                const questId = updatedQuestData.id;
 
-    if (jsonExportCloseButton) {
-        jsonExportCloseButton.addEventListener('click', () => {
-            jsonExportOverlay.style.display = 'none';
+                if (!questId || !quests.some(q => q.id === questId)) {
+                    alert("JSON must have a valid 'id' matching the current quest.");
+                    return;
+                }
+
+                // This is a temporary object to hold the changes.
+                // It will be used to repopulate the overlay.
+                const tempQuest = {
+                    ...quests.find(q => q.id === questId), // Start with existing data
+                    ...updatedQuestData // Overwrite with new data
+                };
+
+                // Repopulate the story beat card with the new data
+                populateAndShowStoryBeatCard(tempQuest);
+
+                alert("Quest details have been updated on the overlay. Click 'Save All Changes' to apply them to the story tree.");
+                jsonEditOverlay.style.display = 'none';
+
+            } catch (e) {
+                alert("Invalid JSON format. Please check the syntax and try again.");
+                console.error("Error parsing quest JSON:", e);
+            }
+        });
+    }
+
+
+    if (jsonEditCloseButton) {
+        jsonEditCloseButton.addEventListener('click', () => {
+            jsonEditOverlay.style.display = 'none';
         });
     }
 
     if (copyJsonButton) {
         copyJsonButton.addEventListener('click', () => {
-            navigator.clipboard.writeText(jsonExportContent.textContent).then(() => {
+            navigator.clipboard.writeText(jsonEditContent.value).then(() => {
                 copyJsonButton.textContent = 'Copied!';
                 setTimeout(() => {
                     copyJsonButton.textContent = 'Copy to Clipboard';


### PR DESCRIPTION
This commit enhances the Story Beats feature by allowing users to edit the quest details directly via a JSON overlay.

Key changes:
- The 'Export Quest to JSON' button now opens a modal with an editable textarea containing the quest's JSON data.
- A 'Save' button has been added to this modal. Clicking it parses the JSON and updates the fields on the main Story Beat Card Overlay.
- These changes are temporary and only affect the view. They are only persisted to the main `quests` data array when the 'Save All Changes' button on the story beat card is clicked.
- This provides a powerful way for users to import or quickly modify quest details, similar to the 'Fill from JSON' feature for characters.