### PR TITLE
fix: Resolve scope issue in Story Beat JSON editor

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7281,7 +7281,6 @@ function displayToast(messageElement) {
     resizeCanvas(); // Set initial canvas size
     drawConnections();
     renderCards();
-    }
 
     if (saveJsonButton) {
         saveJsonButton.addEventListener('click', () => {
@@ -7333,6 +7332,7 @@ function displayToast(messageElement) {
                 alert('Failed to copy JSON.');
             });
         });
+    }
     }
 
     if (storyBeatCardOverlay) {


### PR DESCRIPTION
This commit fixes a `ReferenceError` that occurred when clicking the 'Save' button in the new Story Beat JSON editor.

The `populateAndShowStoryBeatCard` function was not accessible from the event listener's scope. This was resolved by moving the event listeners for the JSON edit modal (`saveJsonButton`, `jsonEditCloseButton`, `copyJsonButton`) inside the `initStoryTree` function, where they have the correct scope to access the necessary functions.