### PR TITLE
fix: Correctly save all quest details and update visuals

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6866,6 +6866,7 @@ function displayToast(messageElement) {
                 completed: row.querySelector('.story-step-checkbox').checked
             }));
 
+            questToUpdate.difficulty = quest.difficulty; // Save difficulty from the temporary quest object
             questToUpdate.detailedRewards = {
                 xp: parseInt(document.getElementById('reward-xp').value, 10) || 0,
                 loot: document.getElementById('reward-loot').value,
@@ -6875,6 +6876,7 @@ function displayToast(messageElement) {
 
             alert('Quest details saved!');
             renderCards(); // Re-render cards to reflect name change
+            drawConnections(); // Redraw connections to reflect parentId changes
         });
 
         const addNpcBtn = document.getElementById('add-npc-btn');


### PR DESCRIPTION
This commit addresses two final bugs in the Story Beat JSON editing feature:

1.  The quest's difficulty rating was not being saved when 'Save All Changes' was clicked. The listener has been updated to include the difficulty value in the save operation.
2.  Visual connector lines were not appearing for new parent-child relationships defined via JSON import. The save listener now calls `drawConnections()` after `renderCards()` to ensure the entire story tree canvas is updated correctly after a save.