### PR TITLE
Fix: Correct layout issues when switching tabs

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -24,9 +24,6 @@ body { margin: 0; font-family: 'Inter', sans-serif; display: flex; height: 100vh
     overflow: hidden;
     padding: 10px;
 }
-#map-container.hidden, .canvas-container.hidden {
-    display: none !important;
-}
 
 .canvas-container {
     width: 100%;

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3931,6 +3931,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const tabContents = document.querySelectorAll('.tab-content');
 
     function switchTab(tabId) {
+        // Hide all main content containers by default
+        if (mapContainer) mapContainer.style.display = 'none';
+        if (noteEditorContainer) noteEditorContainer.style.display = 'none';
+        if (characterSheetContainer) characterSheetContainer.style.display = 'none';
+        if (storyTreeContainer) storyTreeContainer.style.display = 'none';
+        if (quoteEditorContainer) quoteEditorContainer.style.display = 'none';
+
+        // Toggle active state for tab buttons and sidebar content
         tabButtons.forEach(btn => {
             btn.classList.toggle('active', btn.getAttribute('data-tab') === tabId);
         });
@@ -3938,18 +3946,15 @@ document.addEventListener('DOMContentLoaded', () => {
             content.classList.toggle('active', content.id === tabId);
         });
 
+        // Show the correct container based on the tabId
         if (tabId === 'tab-notes') {
-            if (mapContainer) mapContainer.classList.add('hidden');
-            if (characterSheetContainer) characterSheetContainer.classList.remove('active');
-            if (noteEditorContainer) noteEditorContainer.classList.add('active');
+            if (noteEditorContainer) noteEditorContainer.style.display = 'flex';
 
             if (!easyMDE && markdownEditorTextarea) {
                 initEasyMDE();
             }
             if (easyMDE && easyMDE.codemirror) {
-                setTimeout(() => {
-                    easyMDE.codemirror.refresh();
-                }, 10);
+                setTimeout(() => easyMDE.codemirror.refresh(), 10);
             }
 
             if (!selectedNoteId || !notesData.some(n => n.id === selectedNoteId)) {
@@ -3968,9 +3973,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         } else if (tabId === 'tab-characters') {
-            if (mapContainer) mapContainer.classList.add('hidden');
-            if (noteEditorContainer) noteEditorContainer.classList.remove('active');
-            if (characterSheetContainer) characterSheetContainer.classList.add('active');
+            if (characterSheetContainer) characterSheetContainer.style.display = 'flex';
 
             if (!selectedCharacterId || !charactersData.some(c => c.id === selectedCharacterId)) {
                 if (charactersData.length > 0) {
@@ -3981,21 +3984,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         } else if (tabId === 'tab-story-beats') {
-            if (mapContainer) mapContainer.classList.add('hidden');
-            if (noteEditorContainer) noteEditorContainer.classList.remove('active');
-            if (characterSheetContainer) characterSheetContainer.classList.remove('active');
             if (storyTreeContainer) {
-                storyTreeContainer.style.display = 'flex'; // Use flex to match container style
+                storyTreeContainer.style.display = 'flex';
                 storyTreeContainer.style.flexGrow = '1';
             }
-            if (quoteEditorContainer) quoteEditorContainer.style.display = 'none';
             initStoryTree();
-        } else {
-            if (mapContainer) mapContainer.classList.remove('hidden');
-            if (noteEditorContainer) noteEditorContainer.classList.remove('active');
-            if (characterSheetContainer) characterSheetContainer.classList.remove('active');
-            if (storyTreeContainer) storyTreeContainer.style.display = 'none';
-            if (quoteEditorContainer) quoteEditorContainer.style.display = 'none';
+        } else { // Default to DM Controls tab
+            if (mapContainer) mapContainer.style.display = 'flex';
+            resizeCanvas(); // Ensure map is resized correctly
         }
     }
 


### PR DESCRIPTION
The previous implementation for switching tabs was causing layout issues, particularly with the story beats canvas remaining visible and squashing the content of other tabs. This change refactors the `switchTab` function to explicitly hide all main content containers before showing the correct one for the selected tab. This ensures that only one main content area is visible at a time, resolving the layout bugs on the characters and DM tools tabs.