### PR TITLE
feat: Update story beat card display

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6605,7 +6605,15 @@ function displayToast(messageElement) {
             if (quest.detailedRewards) {
                 const rewards = [];
                 if (quest.detailedRewards.xp) rewards.push(`XP: ${quest.detailedRewards.xp}`);
-                if (quest.detailedRewards.information) rewards.push(`${quest.detailedRewards.information}`);
+                if (quest.detailedRewards.information) {
+                    const fullInfo = quest.detailedRewards.information;
+                    const infoWords = fullInfo.split(/\s+/);
+                    if (infoWords.length > 30) {
+                        rewards.push(infoWords.slice(0, 30).join(' ') + '...');
+                    } else {
+                        rewards.push(fullInfo);
+                    }
+                }
                 rewardsContainer.textContent = rewards.join(', ');
             }
             overlay.appendChild(rewardsContainer);


### PR DESCRIPTION
- Truncates the quest description to 15 words on the story beat cards to prevent text overflow.
- Modifies the rewards display on the cards to only show XP and lore/info, removing the "Loot:" and "Magic Items:" fields to make the cards less cluttered.
- Truncates the lore/info description to 30 words.