### PR TITLE
This commit fixes three issues identified in the initial implementati…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -539,6 +539,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
+            if (!transform.initialized) {
+                const hRatio = dmCanvas.width / img.width;
+                const vRatio = dmCanvas.height / img.height;
+                const ratio = Math.min(hRatio, vRatio);
+                const imgScaledWidth = img.width * ratio;
+                const imgScaledHeight = img.height * ratio;
+                const centerShift_x = (dmCanvas.width - imgScaledWidth) / 2;
+                const centerShift_y = (dmCanvas.height - imgScaledHeight) / 2;
+
+                transform.scale = ratio;
+                transform.originX = centerShift_x;
+                transform.originY = centerShift_y;
+                transform.initialized = true;
+            }
+
             ctx.clearRect(0, 0, dmCanvas.width, dmCanvas.height);
             ctx.save();
             ctx.translate(transform.originX, transform.originY);
@@ -1872,7 +1887,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         name: file.name,
                         overlays: [],
                         mode: 'edit',
-                        transform: { scale: 1, originX: 0, originY: 0 }
+                        transform: { scale: 1, originX: 0, originY: 0, initialized: false }
                     });
 
                     if (!isEditMode) {
@@ -2090,8 +2105,7 @@ document.addEventListener('DOMContentLoaded', () => {
             sendMapTransformToPlayerView(transform);
         });
         
-        dmCanvas.addEventListener('mousemove', handleMouseMoveOnCanvas);
-        drawingCanvas.addEventListener('mousemove', (e) => {
+        mapContainer.addEventListener('mousemove', (e) => {
             if (isPanning) {
                 const mapData = detailedMapData.get(selectedMapFileName);
                 if (!mapData) return;
@@ -2100,7 +2114,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 displayMapOnCanvas(selectedMapFileName);
                 sendMapTransformToPlayerView(mapData.transform);
             } else {
-                 handleMouseMoveOnCanvas(e);
+                handleMouseMoveOnCanvas(e);
             }
         });
         dmCanvas.addEventListener('mouseout', () => {
@@ -2518,7 +2532,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                     url: url,
                                     overlays: definition.overlays || [],
                                     mode: definition.mode || 'edit',
-                                    transform: definition.transform || { scale: 1, originX: 0, originY: 0 }
+                                    transform: definition.transform ? { ...definition.transform, initialized: true } : { scale: 1, originX: 0, originY: 0, initialized: false }
                                 });
                                 displayedFileNames.add(mapName);
                             });
@@ -2787,7 +2801,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     url: null,
                     overlays: definition.overlays || [],
                     mode: definition.mode || 'edit',
-                    transform: definition.transform || { scale: 1, originX: 0, originY: 0 }
+                    transform: definition.transform ? { ...definition.transform, initialized: true } : { scale: 1, originX: 0, originY: 0, initialized: false }
                 });
                 displayedFileNames.add(mapName);
             }

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -207,16 +207,17 @@ function drawOverlays_PlayerView(overlays) {
 
             if (overlay.character_portrait) {
                 const img = new Image();
-                img.onload = function() {
-                    // Note: We don't save/restore here because the whole function does it.
+                img.src = overlay.character_portrait;
+                if (img.complete) {
                     pCtx.beginPath();
                     pCtx.arc(canvasX, canvasY, iconSize / 2, 0, Math.PI * 2, true);
                     pCtx.closePath();
                     pCtx.clip();
                     pCtx.drawImage(img, canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
                     pCtx.beginPath(); // Reset path after clipping
-                };
-                img.src = overlay.character_portrait;
+                } else {
+                    img.onload = () => drawMapAndOverlays();
+                }
             }
         }
         });


### PR DESCRIPTION
…on of the map pan and zoom feature.

1.  **Fix panning/dragging:** The `mousemove` event listener for panning was moved from the `drawingCanvas` to the `mapContainer` to ensure consistent event handling and allow the user to drag the map correctly.

2.  **Correct default map view:** Implemented a one-time centering mechanism for newly uploaded maps. Maps now default to a centered, scaled-to-fit view instead of appearing in the top-left corner. This behavior is ignored if a transform is already present in a loaded campaign file.

3.  **Resolve player view icon glitches:** The `onload` handler for character portrait images on the player view was updated to trigger a full redraw of the canvas. This prevents rendering artifacts, such as duplicated or incorrectly scaled icons, when the map is panned or zoomed.