### PR TITLE
This commit fixes issues related to the synchronization of the DM and…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2962,10 +2962,17 @@ document.addEventListener('DOMContentLoaded', () => {
                                     return overlay;
                                 });
 
+                            const normalizedTransform = {
+                                scale: mapData.transform.scale,
+                                originXRatio: mapData.transform.originX / dmCanvas.width,
+                                originYRatio: mapData.transform.originY / dmCanvas.height
+                            };
                             playerWindow.postMessage({
                                 type: 'loadMap',
                                 mapDataUrl: base64dataUrl,
-                                overlays: JSON.parse(JSON.stringify(visibleOverlays))
+                                overlays: JSON.parse(JSON.stringify(visibleOverlays)),
+                                transform: normalizedTransform,
+                                dmCanvasSize: { width: dmCanvas.width, height: dmCanvas.height }
                             }, '*');
                             console.log(`Sent map "${mapFileName}" and ${visibleOverlays.length} visible overlays to player view.`);
                         };
@@ -2997,9 +3004,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function sendMapTransformToPlayerView(transform) {
         if (playerWindow && !playerWindow.closed) {
+            const normalizedTransform = {
+                scale: transform.scale,
+                originXRatio: transform.originX / dmCanvas.width,
+                originYRatio: transform.originY / dmCanvas.height
+            };
             playerWindow.postMessage({
                 type: 'mapTransformUpdate',
-                transform: transform
+                transform: normalizedTransform,
+                dmCanvasSize: { width: dmCanvas.width, height: dmCanvas.height }
             }, '*');
         }
     }

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -265,11 +265,16 @@ window.addEventListener('message', (event) => {
                 playerMapContainer.style.display = 'flex';
 
                 if (data.mapDataUrl) {
-                    // console.log(`Player view received loadMap: ${data.mapDataUrl.substring(0,30)}...`);
                     const img = new Image();
                     img.onload = () => {
                         currentMapImage = img;
                         currentOverlays = data.overlays || [];
+                        if (data.transform) {
+                            const normalizedTransform = data.transform;
+                            currentMapTransform.scale = normalizedTransform.scale;
+                            currentMapTransform.originX = normalizedTransform.originXRatio * playerCanvas.width;
+                            currentMapTransform.originY = normalizedTransform.originYRatio * playerCanvas.height;
+                        }
                         console.log("Player view: Map image loaded, drawing map and overlays. Overlays received:", currentOverlays.length);
                         drawMapAndOverlays();
                     };
@@ -286,8 +291,11 @@ window.addEventListener('message', (event) => {
                 }
                 break;
             case 'mapTransformUpdate':
-                if (data.transform) {
-                    currentMapTransform = data.transform;
+                if (data.transform && data.dmCanvasSize) {
+                    const normalizedTransform = data.transform;
+                    currentMapTransform.scale = normalizedTransform.scale;
+                    currentMapTransform.originX = normalizedTransform.originXRatio * playerCanvas.width;
+                    currentMapTransform.originY = normalizedTransform.originYRatio * playerCanvas.height;
                     drawMapAndOverlays();
                 }
                 break;


### PR DESCRIPTION
… Player map views. The transform (pan/zoom) data is now normalized before being sent and denormalized upon receipt to account for different canvas sizes and aspect ratios.

Specifically, this commit addresses the following problems:
1.  **Incorrect Initial Player View:** The player view now receives the correct initial transform when a map is loaded, ensuring it displays as a "fit" view rather than a "filled/cropped" view.
2.  **Out-of-sync Panning and Zooming:** The transform origin is now sent as a ratio of the canvas dimensions. The player view uses this ratio to calculate the correct origin for its own canvas size, making the pan and zoom operations appear identical for both users.
3.  **State Not Updating on Map Switch:** The player view now correctly loads the transform state of the newly selected map when the DM switches between maps, instead of retaining the transform of the previous one.