### PR TITLE
This commit fixes the map synchronization by ensuring the player's ca…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2962,16 +2962,11 @@ document.addEventListener('DOMContentLoaded', () => {
                                     return overlay;
                                 });
 
-                            const normalizedTransform = {
-                                scale: mapData.transform.scale,
-                                originXRatio: mapData.transform.originX / dmCanvas.width,
-                                originYRatio: mapData.transform.originY / dmCanvas.height
-                            };
                             playerWindow.postMessage({
                                 type: 'loadMap',
                                 mapDataUrl: base64dataUrl,
                                 overlays: JSON.parse(JSON.stringify(visibleOverlays)),
-                                transform: normalizedTransform,
+                                transform: mapData.transform,
                                 dmCanvasSize: { width: dmCanvas.width, height: dmCanvas.height }
                             }, '*');
                             console.log(`Sent map "${mapFileName}" and ${visibleOverlays.length} visible overlays to player view.`);
@@ -3004,14 +2999,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function sendMapTransformToPlayerView(transform) {
         if (playerWindow && !playerWindow.closed) {
-            const normalizedTransform = {
-                scale: transform.scale,
-                originXRatio: transform.originX / dmCanvas.width,
-                originYRatio: transform.originY / dmCanvas.height
-            };
             playerWindow.postMessage({
                 type: 'mapTransformUpdate',
-                transform: normalizedTransform,
+                transform: transform,
                 dmCanvasSize: { width: dmCanvas.width, height: dmCanvas.height }
             }, '*');
         }

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -115,9 +115,8 @@ function drawMapAndOverlays() {
         return;
     }
 
-    playerCanvas.width = playerMapContainer.clientWidth;
-    playerCanvas.height = playerMapContainer.clientHeight;
-
+    // Canvas width and height are now set by the message listener.
+    // We just clear it.
     pCtx.clearRect(0, 0, playerCanvas.width, playerCanvas.height);
     pCtx.save();
 
@@ -261,6 +260,7 @@ window.addEventListener('message', (event) => {
                     }
                 }
 
+            case 'loadMap':
                 slideshowContainer.style.display = 'none';
                 playerMapContainer.style.display = 'flex';
 
@@ -269,11 +269,12 @@ window.addEventListener('message', (event) => {
                     img.onload = () => {
                         currentMapImage = img;
                         currentOverlays = data.overlays || [];
+                        if (data.dmCanvasSize) {
+                            playerCanvas.width = data.dmCanvasSize.width;
+                            playerCanvas.height = data.dmCanvasSize.height;
+                        }
                         if (data.transform) {
-                            const normalizedTransform = data.transform;
-                            currentMapTransform.scale = normalizedTransform.scale;
-                            currentMapTransform.originX = normalizedTransform.originXRatio * playerCanvas.width;
-                            currentMapTransform.originY = normalizedTransform.originYRatio * playerCanvas.height;
+                            currentMapTransform = data.transform;
                         }
                         console.log("Player view: Map image loaded, drawing map and overlays. Overlays received:", currentOverlays.length);
                         drawMapAndOverlays();
@@ -284,7 +285,7 @@ window.addEventListener('message', (event) => {
                         currentMapImage = null;
                         currentOverlays = [];
                     };
-                    img.src = data.mapDataUrl; // Expecting base64 Data URL
+                    img.src = data.mapDataUrl;
                 } else {
                     console.warn("loadMap message received without mapDataUrl.");
                     drawPlaceholder("Received invalid map data from DM.");
@@ -292,10 +293,9 @@ window.addEventListener('message', (event) => {
                 break;
             case 'mapTransformUpdate':
                 if (data.transform && data.dmCanvasSize) {
-                    const normalizedTransform = data.transform;
-                    currentMapTransform.scale = normalizedTransform.scale;
-                    currentMapTransform.originX = normalizedTransform.originXRatio * playerCanvas.width;
-                    currentMapTransform.originY = normalizedTransform.originYRatio * playerCanvas.height;
+                    playerCanvas.width = data.dmCanvasSize.width;
+                    playerCanvas.height = data.dmCanvasSize.height;
+                    currentMapTransform = data.transform;
                     drawMapAndOverlays();
                 }
                 break;


### PR DESCRIPTION
…nvas has the same resolution and aspect ratio as the DM's canvas.

The previous normalization/denormalization logic has been reverted in favor of this more direct approach.

- The DM view now sends its canvas dimensions along with the raw transform data to the player view.
- The player view's message handlers (`loadMap` and `mapTransformUpdate`) have been updated to set the player's canvas `width` and `height` attributes to match the DM's.
- The player view then applies the raw transform data directly, as the coordinate systems are now 1:1.
- Existing CSS on the player view handles the visual scaling of the canvas element to fit the screen while maintaining the correct aspect ratio.

This resolves the reported issues where the two views were out of sync, the initial view was cropped, and the view state did not update correctly on map switch.