### PR TITLE
This commit introduces two new features/fixes based on user feedback.

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -115,8 +115,9 @@ function drawMapAndOverlays() {
         return;
     }
 
-    // Canvas width and height are now set by the message listener.
-    // We just clear it.
+    playerCanvas.width = playerMapContainer.clientWidth;
+    playerCanvas.height = playerMapContainer.clientHeight;
+
     pCtx.clearRect(0, 0, playerCanvas.width, playerCanvas.height);
     pCtx.save();
 
@@ -269,33 +270,39 @@ window.addEventListener('message', (event) => {
                     img.onload = () => {
                         currentMapImage = img;
                         currentOverlays = data.overlays || [];
-                        if (data.dmCanvasSize) {
-                            playerCanvas.width = data.dmCanvasSize.width;
-                            playerCanvas.height = data.dmCanvasSize.height;
+                        if (data.viewRectangle) {
+                            const viewRect = data.viewRectangle;
+                            const hScale = playerCanvas.width / viewRect.width;
+                            const vScale = playerCanvas.height / viewRect.height;
+                            const scale = Math.min(hScale, vScale);
+                            const renderedWidth = viewRect.width * scale;
+                            const renderedHeight = viewRect.height * scale;
+                            currentMapTransform.scale = scale;
+                            currentMapTransform.originX = -viewRect.x * scale + (playerCanvas.width - renderedWidth) / 2;
+                            currentMapTransform.originY = -viewRect.y * scale + (playerCanvas.height - renderedHeight) / 2;
                         }
-                        if (data.transform) {
-                            currentMapTransform = data.transform;
-                        }
-                        console.log("Player view: Map image loaded, drawing map and overlays. Overlays received:", currentOverlays.length);
                         drawMapAndOverlays();
                     };
                     img.onerror = () => {
-                        console.error(`Error loading image for player view (loadMap).`);
                         drawPlaceholder("Error loading map.");
                         currentMapImage = null;
-                        currentOverlays = [];
                     };
                     img.src = data.mapDataUrl;
                 } else {
-                    console.warn("loadMap message received without mapDataUrl.");
                     drawPlaceholder("Received invalid map data from DM.");
                 }
                 break;
             case 'mapTransformUpdate':
-                if (data.transform && data.dmCanvasSize) {
-                    playerCanvas.width = data.dmCanvasSize.width;
-                    playerCanvas.height = data.dmCanvasSize.height;
-                    currentMapTransform = data.transform;
+                if (data.viewRectangle) {
+                    const viewRect = data.viewRectangle;
+                    const hScale = playerCanvas.width / viewRect.width;
+                    const vScale = playerCanvas.height / viewRect.height;
+                    const scale = Math.min(hScale, vScale);
+                    const renderedWidth = viewRect.width * scale;
+                    const renderedHeight = viewRect.height * scale;
+                    currentMapTransform.scale = scale;
+                    currentMapTransform.originX = -viewRect.x * scale + (playerCanvas.width - renderedWidth) / 2;
+                    currentMapTransform.originY = -viewRect.y * scale + (playerCanvas.height - renderedHeight) / 2;
                     drawMapAndOverlays();
                 }
                 break;


### PR DESCRIPTION
1.  **Add Re-click to Center Feature:** The DM can now click on the currently active map in the sidebar list to reset its pan and zoom to the default, centered "zoom-to-fit" view. This action resets the view for both the DM and the player.

2.  **Refactor View Synchronization Logic:** The method for synchronizing the DM and player canvases has been completely refactored to be more robust and handle differing canvas aspect ratios.
    - The DM view now calculates the visible portion of the map in image-space coordinates (a 'view rectangle').
    - This `viewRectangle` is sent to the player view during map loads and transform updates.
    - The player view now resizes its canvas to fill its container and then calculates the correct local transform (`scale` and `origin`) required to display the received `viewRectangle`, fitting it perfectly within its viewport.

This new synchronization logic ensures that the content visible to the player is identical to the content visible to the DM, regardless of their individual window or canvas sizes.