### PR TITLE
This commit fixes two critical bugs related to map interactions and p…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1577,52 +1577,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
 
-    dmCanvas.addEventListener('mousemove', (event) => {
-        if (isDraggingToken && draggedToken) {
-            const imageCoords = getRelativeCoords(event.offsetX, event.offsetY);
-            if (imageCoords) {
-                const dx = imageCoords.x - dragStartX;
-                const dy = imageCoords.y - dragStartY;
-
-                draggedToken.x += dx;
-                draggedToken.y += dy;
-
-                dragStartX = imageCoords.x;
-                dragStartY = imageCoords.y;
-
-                if (selectedMapFileName) {
-                    displayMapOnCanvas(selectedMapFileName);
-                }
-            }
-        } else if ((isMovingPolygon && polygonBeingMoved && moveStartPoint) || (isMovingNote && noteBeingMoved && moveStartPoint) || (isMovingCharacter && characterBeingMoved && moveStartPoint)) {
-            const imageCoords = getRelativeCoords(event.offsetX, event.offsetY);
-            if (imageCoords) {
-                currentDragOffsets.x = imageCoords.x - moveStartPoint.x;
-                currentDragOffsets.y = imageCoords.y - moveStartPoint.y;
-
-                const parentMapName = isMovingPolygon ? polygonBeingMoved.parentMapName : (isMovingNote ? noteBeingMoved.parentMapName : characterBeingMoved.parentMapName);
-
-                if (selectedMapFileName === parentMapName && currentMapDisplayData.img && currentMapDisplayData.img.complete) {
-                    const ctx = dmCanvas.getContext('2d');
-                    ctx.clearRect(0, 0, dmCanvas.width, dmCanvas.height);
-                    ctx.drawImage(
-                        currentMapDisplayData.img, 0, 0,
-                        currentMapDisplayData.imgWidth, currentMapDisplayData.imgHeight,
-                        currentMapDisplayData.offsetX, currentMapDisplayData.offsetY,
-                        currentMapDisplayData.scaledWidth, currentMapDisplayData.scaledHeight
-                    );
-                    const mapData = detailedMapData.get(selectedMapFileName);
-                    if (mapData && mapData.overlays) {
-                        drawOverlays(mapData.overlays);
-                    }
-                } else if (selectedMapFileName === parentMapName) {
-                    displayMapOnCanvas(selectedMapFileName);
-                }
-            }
-        } else {
-            handleMouseMoveOnCanvas(event);
-        }
-    });
 
     dmCanvas.addEventListener('mouseup', (event) => {
         if (event.button !== 0) return;
@@ -2120,7 +2074,29 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         mapContainer.addEventListener('mousemove', (e) => {
-            if (isPanning) {
+            const imageCoords = getRelativeCoords(e.offsetX, e.offsetY);
+
+            if (isDraggingToken && draggedToken) {
+                if (imageCoords) {
+                    const dx = imageCoords.x - dragStartX;
+                    const dy = imageCoords.y - dragStartY;
+                    draggedToken.x += dx;
+                    draggedToken.y += dy;
+                    dragStartX = imageCoords.x;
+                    dragStartY = imageCoords.y;
+                    if (selectedMapFileName) {
+                        displayMapOnCanvas(selectedMapFileName);
+                    }
+                }
+            } else if ((isMovingPolygon && polygonBeingMoved && moveStartPoint) || (isMovingNote && noteBeingMoved && moveStartPoint) || (isMovingCharacter && characterBeingMoved && moveStartPoint)) {
+                if (imageCoords) {
+                    currentDragOffsets.x = imageCoords.x - moveStartPoint.x;
+                    currentDragOffsets.y = imageCoords.y - moveStartPoint.y;
+                    if (selectedMapFileName) {
+                        displayMapOnCanvas(selectedMapFileName);
+                    }
+                }
+            } else if (isPanning) {
                 const mapData = detailedMapData.get(selectedMapFileName);
                 if (!mapData) return;
                 mapData.transform.originX = e.clientX - panStartX;

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -88,6 +88,7 @@ let currentMapImage = null;
 let currentOverlays = [];
 let initiativeTokens = [];
 let currentMapTransform = { scale: 1, originX: 0, originY: 0 };
+const imageCache = new Map();
 let currentMapDisplayData = {
     img: null,
     ratio: 1,
@@ -213,8 +214,14 @@ function drawOverlays_PlayerView(overlays) {
             pCtx.fillText('👤', canvasX, canvasY);
 
             if (overlay.character_portrait) {
-                const img = new Image();
-                img.src = overlay.character_portrait;
+                let img = imageCache.get(overlay.character_portrait);
+                if (!img) {
+                    img = new Image();
+                    img.src = overlay.character_portrait;
+                    img.onload = () => drawMapAndOverlays();
+                    imageCache.set(overlay.character_portrait, img);
+                }
+
                 if (img.complete) {
                     pCtx.beginPath();
                     pCtx.arc(canvasX, canvasY, iconSize / 2, 0, Math.PI * 2, true);
@@ -222,8 +229,6 @@ function drawOverlays_PlayerView(overlays) {
                     pCtx.clip();
                     pCtx.drawImage(img, canvasX - iconSize / 2, canvasY - iconSize / 2, iconSize, iconSize);
                     pCtx.beginPath(); // Reset path after clipping
-                } else {
-                    img.onload = () => drawMapAndOverlays();
                 }
             }
         }
@@ -580,8 +585,14 @@ function drawToken(ctx, token) {
     ctx.clip();
 
     if (token.portrait) {
-        const img = new Image();
-        img.src = token.portrait;
+        let img = imageCache.get(token.portrait);
+        if (!img) {
+            img = new Image();
+            img.src = token.portrait;
+            img.onload = () => drawMapAndOverlays();
+            imageCache.set(token.portrait, img);
+        }
+
         if (img.complete) {
             ctx.drawImage(img, canvasX - size / 2, canvasY - size / 2, size, size);
         } else {
@@ -590,7 +601,6 @@ function drawToken(ctx, token) {
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
             ctx.fillText(token.initials, canvasX, canvasY);
-            img.onload = () => drawMapAndOverlays();
         }
     } else {
         ctx.fillStyle = '#e0e0e0';


### PR DESCRIPTION
…layer-view rendering.

1.  **Fix Disappearing Icons on Drag:** All `mousemove` logic for the DM's map has been consolidated into a single event listener on the `mapContainer`. This listener now correctly prioritizes the user's intent (dragging a token vs. panning the map) and ensures that the canvas is continuously redrawn during any drag operation, preventing all other icons from disappearing.

2.  **Fix Player View Icon Duplication:** An image cache has been implemented on the player's view. Previously, new `Image` objects were created on every render frame, leading to a race condition where multiple `onload` events would fire and draw icons on top of each other. The drawing functions now use the cache to ensure each image is loaded only once, eliminating the duplication artifact.