### PR TITLE
Fix: Correct styling for story beats context menu

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7091,13 +7091,16 @@ function displayToast(messageElement) {
     // --- Context Menu Logic ---
 
     const createContextMenu = (e, options) => {
-        const existingMenu = document.querySelector('.story-tree-context-menu');
+        const existingMenu = document.querySelector('.context-menu');
         if (existingMenu) existingMenu.remove();
 
-            const menu = document.createElement('ul');
-        menu.classList.add('story-tree-context-menu');
-            menu.style.left = `${e.clientX}px`;
-            menu.style.top = `${e.clientY}px`;
+        const menu = document.createElement('div');
+        menu.classList.add('context-menu');
+        menu.style.left = `${e.clientX}px`;
+        menu.style.top = `${e.clientY}px`;
+
+        const ul = document.createElement('ul');
+        menu.appendChild(ul);
 
         options.forEach(option => {
             const item = document.createElement('li');
@@ -7112,7 +7115,7 @@ function displayToast(messageElement) {
                     menu.remove();
                 });
                 }
-            menu.appendChild(item);
+            ul.appendChild(item);
             });
 
         document.body.appendChild(menu);


### PR DESCRIPTION
The context menu on the story beats tab was not styled correctly. It appeared as a bulleted list in the top right of the screen.

This was because the JavaScript code was creating a `<ul>` element with a custom class, instead of a `<div>` with the `context-menu` class containing a `<ul>`, which is the structure used by other context menus in the application.

This change updates the `createContextMenu` function in `dm_view.js` to create the context menu with the correct HTML structure and class, so that it will be styled correctly by the existing CSS.