### PR TITLE
feat: Implement quest trigger linking

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -249,6 +249,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ];
     let nextQuestId = 2;
     let selectedQuestId = 1;
+    let activeOverlayCardId = null;
 
     // Initiative Tracker State Variables
     let savedInitiatives = {}; // Object to store saved initiatives: { "name": [...] }
@@ -6654,7 +6655,6 @@ function displayToast(messageElement) {
         let panStartY = 0;
     let moveStartX = 0;
     let moveStartY = 0;
-    let activeOverlayCardId = null;
     let linkSourceId = null;
 
     // --- Core Functions ---


### PR DESCRIPTION
This change introduces the ability for users to link success and failure triggers of a quest to the starting trigger of another quest.

- The data structure for triggers has been updated from an array of strings to an array of objects, where each object contains the trigger text and an optional `linkedQuestId`.
- The story beat card overlay has been updated with UI elements (link/unlink buttons) and logic to manage these links.
- A context menu is now displayed when the "Link" button is clicked, allowing the user to select a quest to link to.
- The changes are backward compatible, with logic added to handle old save files with the previous string-based trigger format.

fix: Correct scope of activeOverlayCardId

This change fixes a `ReferenceError` that occurred when clicking the "Link" button for a quest trigger. The `activeOverlayCardId` variable was incorrectly scoped within the `initStoryTree` function, making it inaccessible to the event listener that handles the linking logic.

The variable declaration has been moved to the top-level scope of the `DOMContentLoaded` event listener, ensuring it is accessible to all functions that need it.