### PR TITLE
feat: Implement quest trigger linking

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -794,6 +794,20 @@ document.addEventListener('DOMContentLoaded', () => {
                     populateAndShowStoryBeatCard(currentQuest);
                 }
             }
+
+            if (e.target.classList.contains('remove-trigger-btn')) {
+                const row = e.target.closest('.trigger-row');
+                if (!row) return;
+                const container = row.parentElement;
+                const triggerType = container.id.replace('quest-', '');
+                const index = parseInt(row.dataset.index, 10);
+                const currentQuest = quests.find(q => q.id === activeOverlayCardId);
+
+                if (currentQuest && currentQuest[triggerType] && currentQuest[triggerType][index]) {
+                    currentQuest[triggerType].splice(index, 1);
+                    populateAndShowStoryBeatCard(currentQuest);
+                }
+            }
         });
     }
 
@@ -7158,44 +7172,23 @@ function displayToast(messageElement) {
         });
 
         // Add/Remove Triggers
-        const setupTriggerList = (containerId, buttonId, isLinkable) => {
-            const container = document.getElementById(containerId);
+        const setupTriggerList = (containerId, buttonId, triggerType) => {
             const addButton = document.getElementById(buttonId);
-
             addButton.addEventListener('click', () => {
-                const newIndex = container.children.length;
-                const newRow = document.createElement('div');
-                newRow.className = 'trigger-row';
-                newRow.dataset.index = newIndex;
-
-                let linkHtml = '';
-                if (isLinkable) {
-                    const triggerType = containerId.replace('quest-', '');
-                    linkHtml = `
-                        <div class="trigger-link-container" data-trigger-type="${triggerType}" data-index="${newIndex}">
-                            <button class="link-trigger-btn" title="Link to another quest's starting trigger">🔗</button>
-                        </div>
-                    `;
-                }
-
-                newRow.innerHTML = `
-                    <div contenteditable="true" class="editable-div trigger-text">New Trigger</div>
-                    ${linkHtml}
-                    <button class="remove-trigger-btn">X</button>
-                `;
-                container.appendChild(newRow);
-            });
-
-            container.addEventListener('click', (e) => {
-                if (e.target.classList.contains('remove-trigger-btn')) {
-                    e.target.closest('.trigger-row').remove();
+                const currentQuest = quests.find(q => q.id === activeOverlayCardId);
+                if (currentQuest) {
+                    if (!currentQuest[triggerType]) {
+                        currentQuest[triggerType] = [];
+                    }
+                    currentQuest[triggerType].push({ text: 'New Trigger', linkedQuestId: null });
+                    populateAndShowStoryBeatCard(currentQuest);
                 }
             });
         };
 
-        setupTriggerList('quest-starting-triggers', 'add-starting-trigger-btn', false);
-        setupTriggerList('quest-success-triggers', 'add-success-trigger-btn', true);
-        setupTriggerList('quest-failure-triggers', 'add-failure-trigger-btn', true);
+        setupTriggerList('quest-starting-triggers', 'add-starting-trigger-btn', 'startingTriggers');
+        setupTriggerList('quest-success-triggers', 'add-success-trigger-btn', 'successTriggers');
+        setupTriggerList('quest-failure-triggers', 'add-failure-trigger-btn', 'failureTriggers');
     };
 
     /**


### PR DESCRIPTION
This change introduces the ability for users to link success and failure triggers of a quest to the starting trigger of another quest.

- The data structure for triggers has been updated from an array of strings to an array of objects, where each object contains the trigger text and an optional `linkedQuestId`.
- The story beat card overlay has been updated with UI elements (link/unlink buttons) and logic to manage these links.
- A context menu is now displayed when the "Link" button is clicked, allowing the user to select a quest to link to.
- The changes are backward compatible, with logic added to handle old save files with the previous string-based trigger format.

fix: Correct scope of activeOverlayCardId

This change fixes a `ReferenceError` that occurred when clicking the "Link" button for a quest trigger. The `activeOverlayCardId` variable was incorrectly scoped within the `initStoryTree` function, making it inaccessible to the event listener that handles the linking logic.

The variable declaration has been moved to the top-level scope of the `DOMContentLoaded` event listener, ensuring it is accessible to all functions that need it.

fix: Refactor trigger management in story beats

This change fixes a bug where the "Link" button for quest triggers was not functioning for newly added triggers. The issue was caused by the UI being updated without updating the underlying data model, leading to inconsistencies.

The trigger management logic has been refactored to update the data model directly when adding or removing triggers, and then re-rendering the UI. This ensures that the data and the UI are always in sync.