### PR TITLE
fix: Correct story beats overlay functionality

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -412,7 +412,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 document.getElementById('save-quest-details-btn').click();
             }
         }
-        overlay.style.display = 'none';
+        storyBeatCardOverlay.style.display = 'none';
         activeOverlayCardId = null;
         originalQuestState = null;
         const currentlySelected = document.querySelector('.card.selected');


### PR DESCRIPTION
This commit fixes two bugs introduced in the previous patch:

1.  A `ReferenceError` for `hideOverlay` is fixed by moving the function and its helpers to a higher scope, making it accessible to all relevant event listeners.
2.  The "unsaved changes" prompt was appearing incorrectly. This is fixed by replacing the brittle `JSON.stringify` comparison with a more robust deep equality check (`isDeepEqual`) and ensuring the data object being compared is constructed correctly.
3.  A `ReferenceError` for `overlay` is fixed by using the correct variable `storyBeatCardOverlay` in the `hideOverlay` function.