### PR TITLE
feat: Add Quests tab to campaign controls footer

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -471,6 +471,41 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* Footer Tabs */
+.footer-tabs {
+    display: flex;
+    background-color: #20262d;
+    border-bottom: 1px solid #3f4c5a;
+}
+
+.footer-tab-button {
+    background: none;
+    border: none;
+    padding: 10px 15px;
+    cursor: pointer;
+    color: #e0e0e0;
+    font-size: 14px;
+    border-bottom: 2px solid transparent;
+}
+
+.footer-tab-button.active {
+    border-bottom-color: #b6cae1;
+    color: #b6cae1;
+}
+
+.footer-tab-content {
+    display: none;
+}
+
+.footer-tab-content.active {
+    display: flex; /* Use flex to layout the content */
+}
+
+#footer-quests {
+    width: 100%;
+    justify-content: space-between;
+}
+
 /* JSON Export Modal Styles */
 #json-export-overlay {
     /* This will use the .modal class, but we can override if needed */

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -479,35 +479,55 @@
         <img src="assets/d20icon.png" alt="d20 icon" style="width: 100%; height: 100%;">
     </div>
     <footer id="dm-floating-footer">
-        <div id="footer-content-wrapper">
-            <div id="footer-left">
-                <h3 style="margin-top: 15px;">Campaign Controls</h3>
-                <div id="footer-timer-audio-area">
-                    <div id="footer-timer-area">
-                        <span id="campaign-timer-display">00:00:00</span>
-                        <button id="campaign-timer-toggle">Resume Campaign</button>
-                    </div>
-                    <div id="audio-controls" style="display: flex; flex-direction: column; gap: 10px; margin-top: 10px;">
-                        <select id="audio-input-select" style="width: 100%; padding: 8px; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0; border-radius: 4px;"></select>
-                        <div style="display: flex; gap: 10px;">
-                            <button id="record-button" style="flex-grow: 1;">Record</button>
-                            <button id="test-audio-button" style="flex-grow: 1;">Test Audio</button>
+        <div class="footer-tabs">
+            <button class="footer-tab-button active" data-tab="footer-tools">Tools</button>
+            <button class="footer-tab-button" data-tab="footer-quests">Quests</button>
+        </div>
+        <div id="footer-tools" class="footer-tab-content active">
+            <div id="footer-content-wrapper">
+                <div id="footer-left">
+                    <h3 style="margin-top: 15px;">Campaign Controls</h3>
+                    <div id="footer-timer-audio-area">
+                        <div id="footer-timer-area">
+                            <span id="campaign-timer-display">00:00:00</span>
+                            <button id="campaign-timer-toggle">Resume Campaign</button>
                         </div>
-                        <audio id="test-audio-playback" controls style="display: none; width: 100%;"></audio>
+                        <div id="audio-controls" style="display: flex; flex-direction: column; gap: 10px; margin-top: 10px;">
+                            <select id="audio-input-select" style="width: 100%; padding: 8px; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0; border-radius: 4px;"></select>
+                            <div style="display: flex; gap: 10px;">
+                                <button id="record-button" style="flex-grow: 1;">Record</button>
+                                <button id="test-audio-button" style="flex-grow: 1;">Test Audio</button>
+                            </div>
+                            <audio id="test-audio-playback" controls style="display: none; width: 100%;"></audio>
+                        </div>
                     </div>
+                </div>
+                <div id="footer-center">
+                    <h3>Campaign Notes</h3>
+                    <div id="footer-notes-area">
+                        <input type="text" id="dm-notes-input" placeholder="Type a quick note and press Enter...">
+                    </div>
+                    <h3 style="margin-top: 15px;">DM Tools</h3>
+                    <ul id="dm-tools-list">
+                        <li data-action="open-initiative-tracker">Initiative Tracker</li>
+                        <li data-action="open-dice-roller">Dice Roller</li>
+                        <li data-action="open-action-log">Action Log</li>
+                    </ul>
                 </div>
             </div>
-            <div id="footer-center">
-                <h3>Campaign Notes</h3>
-                <div id="footer-notes-area">
-                    <input type="text" id="dm-notes-input" placeholder="Type a quick note and press Enter...">
-                </div>
-                <h3 style="margin-top: 15px;">DM Tools</h3>
-                <ul id="dm-tools-list">
-                    <li data-action="open-initiative-tracker">Initiative Tracker</li>
-                    <li data-action="open-dice-roller">Dice Roller</li>
-                    <li data-action="open-action-log">Action Log</li>
-                </ul>
+        </div>
+        <div id="footer-quests" class="footer-tab-content" style="display: none;">
+            <div id="footer-quests-left" style="flex: 1; padding: 10px;">
+                <h3>Active Quests</h3>
+                <!-- Active quests content will go here -->
+            </div>
+            <div id="footer-quests-center" style="flex: 2; padding: 10px; border-left: 1px solid #4a5f7a; border-right: 1px solid #4a5f7a;">
+                <h3>Active Quest Story Steps</h3>
+                <!-- Story steps content will go here -->
+            </div>
+            <div id="footer-quests-right" style="flex: 1; padding: 10px;">
+                <h3>Available Quests</h3>
+                <!-- Available quests content will go here -->
             </div>
         </div>
     </footer>

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7571,4 +7571,28 @@ function displayToast(messageElement) {
             }
         });
     }
+
+    const footerTabs = document.querySelector('.footer-tabs');
+    if (footerTabs) {
+        footerTabs.addEventListener('click', (event) => {
+            if (event.target.classList.contains('footer-tab-button')) {
+                const targetTab = event.target.dataset.tab;
+
+                document.querySelectorAll('.footer-tab-button').forEach(button => {
+                    button.classList.remove('active');
+                });
+                event.target.classList.add('active');
+
+                document.querySelectorAll('.footer-tab-content').forEach(content => {
+                    if (content.id === targetTab) {
+                        content.style.display = 'flex';
+                        content.classList.add('active');
+                    } else {
+                        content.style.display = 'none';
+                        content.classList.remove('active');
+                    }
+                });
+            }
+        });
+    }
 });


### PR DESCRIPTION
This commit introduces a new "Quests" tab to the campaign controls footer in the DM view. The existing footer content has been moved into a "Tools" tab.

The "Quests" tab is structured with three sections:
- Active Quests (left)
- Active Quest Story Steps (center)
- Available Quests (right)

This change includes modifications to the HTML, CSS, and JavaScript to create the tabbed interface and handle tab switching.