### PR TITLE
feat: Implement quest footer and update quest status handling

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -534,6 +534,9 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 
 .footer-content-container {
     display: grid;
+    flex-grow: 1;
+    min-height: 0;
+    padding: 10px;
 }
 
 .footer-tab-content {
@@ -541,6 +544,7 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     width: 100%;
     visibility: hidden;
     display: flex; /* Keep flex for internal layout */
+    min-height: 0;
 }
 
 .footer-tab-content.active {
@@ -550,11 +554,14 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 #footer-quests {
     width: 100%;
     justify-content: space-between;
+    gap: 10px;
 }
 
 #footer-quests-left, #footer-quests-right, #footer-quests-center {
     overflow-y: auto;
-    max-height: 150px;
+    padding: 10px;
+    background-color: #15191e;
+    border-radius: 4px;
 }
 
 /* JSON Export Modal Styles */
@@ -855,6 +862,9 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     z-index: 1002;
     transition: transform 0.3s ease-in-out;
     transform: translateY(100%); /* Initially hidden */
+    display: flex;
+    flex-direction: column;
+    height: 30vh;
 }
 
 #dm-floating-footer.visible {
@@ -868,6 +878,8 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     padding: 15px;
     padding-right: 100px; /* Space for the floating d20 icon */
     box-sizing: border-box;
+    flex-grow: 1;
+    min-height: 0;
 }
 
 #footer-left {

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7293,6 +7293,26 @@ function displayToast(messageElement) {
         setupTriggerList('quest-starting-triggers', 'add-starting-trigger-btn', 'startingTriggers');
         setupTriggerList('quest-success-triggers', 'add-success-trigger-btn', 'successTriggers');
         setupTriggerList('quest-failure-triggers', 'add-failure-trigger-btn', 'failureTriggers');
+
+        const storyStepsContainer = document.getElementById('quest-story-steps');
+        if (storyStepsContainer) {
+            storyStepsContainer.addEventListener('change', (e) => {
+                if (e.target.classList.contains('story-step-checkbox')) {
+                    const sIndex = parseInt(e.target.closest('.story-step-row').dataset.index, 10);
+                    const questToUpdate = quests.find(q => q.id === activeOverlayCardId);
+
+                    if (questToUpdate && questToUpdate.storySteps[sIndex]) {
+                        questToUpdate.storySteps[sIndex].completed = e.target.checked;
+
+                        // Sync with footer
+                        const footerCheckbox = document.querySelector(`#footer-quests-left .quest-steps-list input[data-quest-id="${activeOverlayCardId}"][data-step-index="${sIndex}"]`);
+                        if (footerCheckbox) {
+                            footerCheckbox.checked = e.target.checked;
+                        }
+                    }
+                }
+            });
+        }
     };
 
 
@@ -7702,6 +7722,14 @@ function displayToast(messageElement) {
                                 const targetQuest = quests.find(q => q.id === qId);
                                 if (targetQuest && targetQuest.storySteps[sIndex]) {
                                     targetQuest.storySteps[sIndex].completed = e.target.checked;
+
+                                    // Sync with open story beat card overlay
+                                    if (storyBeatCardOverlay.style.display === 'flex' && activeOverlayCardId === qId) {
+                                        const overlayCheckbox = storyBeatCardOverlay.querySelector(`.story-step-row[data-index="${sIndex}"] .story-step-checkbox`);
+                                        if (overlayCheckbox) {
+                                            overlayCheckbox.checked = e.target.checked;
+                                        }
+                                    }
                                 }
                             });
 


### PR DESCRIPTION
This commit introduces several new features and improvements to the quest management system in the DM's view.

- **Default Quest Status:** All story beat cards now default to a status of 'Unavailable'. This applies to newly created quests and is backward compatible with older save files that do not have a `questStatus` field.

- **Quest Footer UI:** A new quest footer has been added to the DM controls tab. This footer displays active and available quests in separate, scrollable lists that fill the height of the footer.

- **Interactive Quest Steps:** Clicking on an active quest in the footer now displays its story steps in a center panel. Each step has a checkbox that allows the DM to track the progress of the quest. The `completed` status of the steps is saved with the campaign data.

- **Two-Way Sync:** The state of the quest step checkboxes is now synchronized in real-time between the footer list and the story beat card overlay.

- **Available to Active:** Clicking on a quest in the 'Available Quests' list now changes its status to 'Active' and moves it to the 'Active Quests' list.