### PR TITLE
feat: Implement quest footer with two-way sync and layout fixes

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7275,6 +7275,24 @@ function displayToast(messageElement) {
             }
         });
 
+            if (storyStepsContainer) {
+                storyStepsContainer.addEventListener('change', (e) => {
+                    if (e.target.classList.contains('story-step-checkbox')) {
+                        const sIndex = parseInt(e.target.closest('.story-step-row').dataset.index, 10);
+                        const questToUpdate = quests.find(q => q.id === activeOverlayCardId);
+
+                        if (questToUpdate && questToUpdate.storySteps[sIndex]) {
+                            questToUpdate.storySteps[sIndex].completed = e.target.checked;
+
+                            const footerCheckbox = document.querySelector(`#footer-quests-center .quest-steps-list input[data-quest-id="${activeOverlayCardId}"][data-step-index="${sIndex}"]`);
+                            if (footerCheckbox) {
+                                footerCheckbox.checked = e.target.checked;
+                            }
+                        }
+                    }
+                });
+            }
+
         // Add/Remove Triggers
         const setupTriggerList = (containerId, buttonId, triggerType) => {
             const addButton = document.getElementById(buttonId);
@@ -7293,26 +7311,6 @@ function displayToast(messageElement) {
         setupTriggerList('quest-starting-triggers', 'add-starting-trigger-btn', 'startingTriggers');
         setupTriggerList('quest-success-triggers', 'add-success-trigger-btn', 'successTriggers');
         setupTriggerList('quest-failure-triggers', 'add-failure-trigger-btn', 'failureTriggers');
-
-        const storyStepsContainer = document.getElementById('quest-story-steps');
-        if (storyStepsContainer) {
-            storyStepsContainer.addEventListener('change', (e) => {
-                if (e.target.classList.contains('story-step-checkbox')) {
-                    const sIndex = parseInt(e.target.closest('.story-step-row').dataset.index, 10);
-                    const questToUpdate = quests.find(q => q.id === activeOverlayCardId);
-
-                    if (questToUpdate && questToUpdate.storySteps[sIndex]) {
-                        questToUpdate.storySteps[sIndex].completed = e.target.checked;
-
-                        // Sync with footer
-                        const footerCheckbox = document.querySelector(`#footer-quests-left .quest-steps-list input[data-quest-id="${activeOverlayCardId}"][data-step-index="${sIndex}"]`);
-                        if (footerCheckbox) {
-                            footerCheckbox.checked = e.target.checked;
-                        }
-                    }
-                }
-            });
-        }
     };
 
 
@@ -7725,7 +7723,7 @@ function displayToast(messageElement) {
 
                                     // Sync with open story beat card overlay
                                     if (storyBeatCardOverlay.style.display === 'flex' && activeOverlayCardId === qId) {
-                                        const overlayCheckbox = storyBeatCardOverlay.querySelector(`.story-step-row[data-index="${sIndex}"] .story-step-checkbox`);
+                                        const overlayCheckbox = storyBeatCardOverlay.querySelector(`#quest-story-steps .story-step-row[data-index="${sIndex}"] .story-step-checkbox`);
                                         if (overlayCheckbox) {
                                             overlayCheckbox.checked = e.target.checked;
                                         }


### PR DESCRIPTION
This commit introduces several new features and improvements to the quest management system in the DM's view, and it also addresses feedback from the previous implementation.

- **Default Quest Status:** All story beat cards now default to a status of 'Unavailable'. This applies to newly created quests and is backward compatible with older save files that do not have a `questStatus` field.

- **Quest Footer UI:** A new quest footer has been added to the DM controls tab. This footer displays active and available quests in separate, scrollable lists that fill the height of the footer.

- **Interactive Quest Steps:** Clicking on an active quest in the footer now displays its story steps in a center panel. Each step has a checkbox that allows the DM to track the progress of the quest.

- **Two-Way Sync:** The state of the quest step checkboxes is now synchronized in real-time between the footer list and the story beat card overlay.

- **Available to Active:** Clicking on a quest in the 'Available Quests' list now changes its status to 'Active' and moves it to the 'Active Quests' list.

- **Bug Fixes:**
  - Resolved a `SyntaxError` caused by a duplicate variable declaration.
  - Corrected the CSS for the footer to ensure the quest list sections fill the available vertical space.
  - Corrected a CSS selector for checkbox synchronization.