### PR TITLE
feat: Implement full quest management footer with triggers and parent…

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -510,6 +510,17 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     padding: 5px 0;
 }
 
+.quest-triggers-list {
+    list-style: disc;
+    padding-left: 20px;
+    margin: 0 0 10px 0;
+}
+
+.parent-quest-button {
+    width: 100%;
+    margin-bottom: 5px;
+}
+
 /* Footer Tabs */
 .footer-tabs {
     display: flex;

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7748,6 +7748,108 @@ function displayToast(messageElement) {
                         placeholder.className = 'footer-placeholder';
                         stepsContainer.appendChild(placeholder);
                     }
+
+                    // Render Success Triggers
+                    const successTriggersTitle = document.createElement('h4');
+                    successTriggersTitle.textContent = 'Success Triggers';
+                    stepsContainer.appendChild(successTriggersTitle);
+
+                    if (quest.successTriggers && quest.successTriggers.length > 0) {
+                        const successList = document.createElement('ul');
+                        successList.className = 'quest-triggers-list';
+                        quest.successTriggers.forEach(trigger => {
+                            const listItem = document.createElement('li');
+                            listItem.textContent = trigger.text;
+                            successList.appendChild(listItem);
+                        });
+                        stepsContainer.appendChild(successList);
+                    } else {
+                        const placeholder = document.createElement('p');
+                        placeholder.textContent = 'No success triggers.';
+                        placeholder.className = 'footer-placeholder';
+                        stepsContainer.appendChild(placeholder);
+                    }
+
+                    // Render Failure Triggers
+                    const failureTriggersTitle = document.createElement('h4');
+                    failureTriggersTitle.textContent = 'Failure Triggers';
+                    stepsContainer.appendChild(failureTriggersTitle);
+
+                    if (quest.failureTriggers && quest.failureTriggers.length > 0) {
+                        const failureList = document.createElement('ul');
+                        failureList.className = 'quest-triggers-list';
+                        quest.failureTriggers.forEach(trigger => {
+                            const listItem = document.createElement('li');
+                            listItem.textContent = trigger.text;
+                            failureList.appendChild(listItem);
+                        });
+                        stepsContainer.appendChild(failureList);
+                    } else {
+                        const placeholder = document.createElement('p');
+                        placeholder.textContent = 'No failure triggers.';
+                        placeholder.className = 'footer-placeholder';
+                        stepsContainer.appendChild(placeholder);
+                    }
+
+                    // Render Parent Quests
+                    const parentQuestsTitle = document.createElement('h4');
+                    parentQuestsTitle.textContent = 'Parent Quests';
+                    stepsContainer.appendChild(parentQuestsTitle);
+
+                    const parentQuests = quests.filter(q => quest.parentIds.includes(q.id));
+
+                    if (parentQuests.length > 0) {
+                        parentQuests.forEach(parentQuest => {
+                            const button = document.createElement('button');
+                            button.textContent = parentQuest.name;
+                            button.className = 'parent-quest-button';
+                            button.dataset.parentQuestId = parentQuest.id;
+                            button.dataset.currentQuestId = quest.id;
+                            stepsContainer.appendChild(button);
+
+                            if (parentQuest.startingTriggers && parentQuest.startingTriggers.length > 0) {
+                                const triggerList = document.createElement('ul');
+                                triggerList.className = 'quest-triggers-list';
+                                parentQuest.startingTriggers.forEach(trigger => {
+                                    const listItem = document.createElement('li');
+                                    listItem.textContent = trigger.text;
+                                    triggerList.appendChild(listItem);
+                                });
+                                stepsContainer.appendChild(triggerList);
+                            }
+                        });
+                    } else {
+                        const placeholder = document.createElement('p');
+                        placeholder.textContent = 'No parent quests.';
+                        placeholder.className = 'footer-placeholder';
+                        stepsContainer.appendChild(placeholder);
+                    }
+                }
+            }
+        });
+    }
+
+    const activeQuestStepsContainer = document.getElementById('footer-quests-center');
+    if (activeQuestStepsContainer) {
+        activeQuestStepsContainer.addEventListener('click', (event) => {
+            if (event.target.classList.contains('parent-quest-button')) {
+                const parentQuestId = parseInt(event.target.dataset.parentQuestId, 10);
+                const currentQuestId = parseInt(event.target.dataset.currentQuestId, 10);
+
+                const parentQuest = quests.find(q => q.id === parentQuestId);
+                const currentQuest = quests.find(q => q.id === currentQuestId);
+
+                if (parentQuest && currentQuest) {
+                    parentQuest.questStatus = 'Active';
+                    currentQuest.questStatus = 'Completed';
+
+                    renderQuestFooter();
+
+                    const activeQuestsContainer = document.getElementById('footer-quests-left');
+                    const newActiveCard = activeQuestsContainer.querySelector(`.quest-footer-card[data-quest-id="${parentQuestId}"]`);
+                    if (newActiveCard) {
+                        newActiveCard.click();
+                    }
                 }
             }
         });


### PR DESCRIPTION
… quests

This commit completes the implementation of the new quest management footer in the DM's view. It builds upon the initial implementation by adding more detailed information and functionality as requested.

- **Default Quest Status:** All story beat cards now default to a status of 'Unavailable'. This applies to newly created quests and is backward compatible with older save files.

- **Quest Footer UI:** A new quest footer has been added to the DM controls tab. This footer displays active and available quests in separate, scrollable lists that fill the height of the footer.

- **Interactive Quest Steps:** Clicking on an active quest in the footer now displays its story steps, success triggers, and failure triggers in a center panel. Each step has a checkbox that allows the DM to track the progress of the quest.

- **Parent Quest Navigation:** After the triggers, the footer now displays buttons for any parent quests of the selected active quest. Clicking a parent quest button completes the current quest, activates the parent quest, and updates the UI to show the new active quest's details.

- **Two-Way Sync:** The state of the quest step checkboxes is synchronized in real-time between the footer list and the story beat card overlay.

- **Bug Fixes:**
  - Resolved a `SyntaxError` caused by a duplicate variable declaration.
  - Corrected the CSS for the footer to ensure the quest list sections fill the available vertical space.
  - Corrected a CSS selector for checkbox synchronization.