### PR TITLE
feat: Implement quest footer and story card glow effects

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -71,6 +71,19 @@ body { margin: 0; font-family: 'Inter', sans-serif; display: flex; height: 100vh
     justify-content: center;
 }
 
+.card-glow-layer {
+    position: absolute;
+    top: -2%;
+    left: -2%;
+    width: 104%;
+    height: 104%;
+    background-color: transparent;
+    border-radius: 12px;
+    z-index: 0;
+    pointer-events: none;
+    transition: box-shadow 0.3s ease-in-out;
+}
+
 .card-background {
     position: absolute;
     top: 0;
@@ -95,6 +108,26 @@ body { margin: 0; font-family: 'Inter', sans-serif; display: flex; height: 100vh
     padding: 1rem;
     box-sizing: border-box;
     text-align: center;
+}
+
+/* Status-based Glows */
+.card.status-unavailable .card-glow-layer {
+    box-shadow: 0 0 15px 5px rgba(255, 0, 0, 0.5); /* 50% red */
+}
+.card.status-available .card-glow-layer {
+    box-shadow: 0 0 15px 5px rgba(0, 0, 255, 0.5); /* 50% blue */
+}
+.card.status-active .card-glow-layer {
+    box-shadow: 0 0 15px 5px #FFD700; /* 100% gold */
+}
+.card.status-completed .card-glow-layer {
+    box-shadow: 0 0 15px 5px #008000; /* 100% green */
+}
+.card.status-failed .card-glow-layer {
+    box-shadow: 0 0 15px 5px #8B0000; /* 100% blood red */
+}
+.card.status-abandoned .card-glow-layer {
+    box-shadow: 0 0 15px 5px #663399; /* 100% royal purple */
 }
 
 .card:hover {


### PR DESCRIPTION
This commit introduces several new features and improvements to the quest management system and the story beats display in the DM's view.

- **Default Quest Status:** All story beat cards now default to a status of 'Unavailable'. This is backward compatible with older save files.

- **Quest Footer UI:** A new quest footer in the DM controls tab now displays active and available quests in separate, scrollable lists that fill the height of the footer.

- **Interactive Quest Details:** Clicking an active quest in the footer displays its story steps, success triggers, and failure triggers. Each step has a checkbox to track progress.

- **Quest Navigation:** The footer now displays buttons for any parent quests. Clicking a parent quest button completes the current quest, activates the parent, and updates the UI.

- **Two-Way Sync:** The state of the quest step checkboxes is synchronized in real-time between the footer list and the story beat card overlay.

- **Glow Effect:** Story beat cards now have a "glow" effect based on their status (e.g., red for 'Unavailable', gold for 'Active'), providing a clear visual indicator.

- **Bug Fixes:**
  - Resolved a `SyntaxError` caused by a duplicate variable declaration.
  - Corrected the CSS for the footer to ensure proper layout.
  - Fixed a bug where the footer would close unexpectedly when activating a parent quest.