### PR TITLE
Feat: Implement Active Quest Footer in DM View

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -489,6 +489,92 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.quest-footer-card {
+    padding: 8px 12px;
+    background-color: #3a4f6a;
+    color: #e0e0e0;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-bottom: 5px;
+    border: 1px solid #5f6a7a;
+}
+
+.quest-footer-card:hover {
+    background-color: #4a5f7a;
+}
+
+.quest-footer-card.selected {
+    border-color: #b6cae1;
+    box-shadow: 0 0 5px rgba(182, 202, 225, 0.5);
+}
+
+.quest-footer-card h4 {
+    margin: 0 0 5px 0;
+    font-size: 1.1em;
+}
+
+.quest-footer-card p {
+    margin: 0;
+    font-size: 0.9em;
+    color: #a0b4c9;
+}
+
+.footer-placeholder {
+    color: #a0b4c9;
+    font-style: italic;
+    padding: 10px;
+    text-align: center;
+}
+
+#footer-active-quest-details h4 {
+    margin-top: 15px;
+    border-bottom: 1px solid #3f4c5a;
+    padding-bottom: 5px;
+}
+
+#footer-active-quest-details h4:first-child {
+    margin-top: 0;
+}
+
+.quest-steps-list {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0;
+}
+
+.quest-steps-list li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 0;
+    font-size: 0.95em;
+}
+
+.quest-steps-list input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
+.quest-steps-list label.completed {
+    text-decoration: line-through;
+    color: #8c96a2;
+}
+
+.quest-triggers-list {
+    list-style: disc;
+    padding-left: 20px;
+    margin: 0 0 10px 0;
+    font-size: 0.9em;
+    color: #a0b4c9;
+}
+
+.successor-quests-container {
+    margin-top: 15px;
+    border-top: 1px solid #3f4c5a;
+    padding-top: 10px;
+}
+
 /* Footer Tabs */
 .footer-tabs {
     display: flex;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -518,17 +518,17 @@
                 </div>
             </div>
             <div id="footer-quests" class="footer-tab-content">
-                <div id="footer-quests-left" style="flex: 1; padding: 10px;">
+                <div id="footer-quests-left" style="flex: 1; padding: 10px; overflow-y: auto;">
                     <h3>Active Quests</h3>
-                    <!-- Active quests content will go here -->
+                    <div id="footer-active-quests-list">
+                        <!-- Active quests content will go here -->
+                    </div>
                 </div>
-                <div id="footer-quests-center" style="flex: 2; padding: 10px; border-left: 1px solid #4a5f7a; border-right: 1px solid #4a5f7a;">
+                <div id="footer-quests-center" style="flex: 3; padding: 10px; border-left: 1px solid #4a5f7a; overflow-y: auto;">
                     <h3>Active Quest Story Steps</h3>
-                    <!-- Story steps content will go here -->
-                </div>
-                <div id="footer-quests-right" style="flex: 1; padding: 10px;">
-                    <h3>Available Quests</h3>
-                    <!-- Available quests content will go here -->
+                    <div id="footer-active-quest-details">
+                        <!-- Story steps content will go here -->
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit introduces a new quest management section in the footer of the DM Controls tab. This feature provides a focused view for managing active quests during a session.

Key changes include:

- **dm_view.html**:
    - Removed the "Available Quests" panel from the quest footer.
    - Restructured the footer to have two main panels: "Active Quests" and "Active Quest Story Steps".
    - Added new element IDs for easier DOM manipulation.

- **dm_view.css**:
    - Added new styles for the quest cards, story step checklists, and successor quest cards in the footer to match the application's theme.
    - Adjusted flex properties to accommodate the new two-panel layout.

- **dm_view.js**:
    - Implemented `renderActiveQuestsInFooter()` to display a list of all quests with the 'Active' status.
    - Implemented `renderActiveQuestDetailsInFooter()` to show the detailed information of the selected active quest, including triggers, description, and story steps.
    - The story steps checklist is now fully synchronized with the main quest data model, ensuring consistency with the "Story Beats" tab.
    - Added functionality to display successor quests. Clicking a successor quest completes the current one, activates the new one, and updates the status of its parents to 'Available'.
    - Integrated the new footer functionality with the rest of the application, ensuring the footer updates automatically when quest data is modified via the "Story Beats" tab.