### PR TITLE
Fix: Prevent footer from closing on parent quest click

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7782,6 +7782,7 @@ function displayToast(messageElement) {
         // Add event listeners for parent quest cards
         detailsContainer.querySelectorAll('.parent-quest-card').forEach(card => {
             card.addEventListener('click', (event) => {
+                event.stopPropagation(); // Prevent the click from bubbling up and closing the footer
                 const clickedParentQuestId = parseInt(event.currentTarget.dataset.parentQuestId, 10);
                 const currentQuestId = quest.id;
 


### PR DESCRIPTION
This commit addresses an issue where clicking on a parent quest card in the DM view footer would cause the entire footer to close.

The bug was caused by the click event propagating up to the document's click listener, which is responsible for closing the footer. The fix is to add `event.stopPropagation()` to the beginning of the click handler for the parent quest cards, preventing the event from bubbling up.