### PR TITLE
feat: Add 'Create Map' button and functionality

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -23,6 +23,7 @@
                     <label for="upload-maps-input">Upload Map Files:</label>
                     <input type="file" id="upload-maps-input" accept="image/*" multiple>
                 </div>
+                <button id="create-map-button" style="margin-top: 10px;">Create Map</button>
                 <ul id="maps-list" style="list-style-type: none; padding-left: 0; margin-top: 10px; overflow-y: auto; max-height: 150px;">
                     <!-- Map files will be listed here -->
                 </ul>
@@ -103,6 +104,12 @@
     <div id="map-container">
         <canvas id="dm-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
+    </div>
+    <div id="map-creation-container" style="display: none; position: relative; width: 100%; height: 100%;">
+        <canvas id="map-creation-canvas" style="border: 1px solid #ccc;"></canvas>
+        <div id="upload-or-choose-bg-container" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+            <button id="upload-or-choose-bg-button">Upload or Choose Background Image</button>
+        </div>
     </div>
     <div id="automation-container" style="display: none; width: 100%;">
         <div id="modules-sidebar">
@@ -562,6 +569,25 @@
             <div style="margin-top: 10px;">
                 <button id="save-json-button">Save</button>
                 <button id="copy-json-button">Copy to Clipboard</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="create-map-modal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button" id="create-map-modal-close-button">&times;</span>
+            <h3>Create New Map</h3>
+            <p>Choose a background image for your new map.</p>
+            <div id="create-map-options-container">
+                <button id="upload-new-image-button">Upload New Image</button>
+                <button id="choose-existing-image-button">Choose From Existing</button>
+                <input type="file" id="new-map-image-upload" accept="image/*" style="display: none;">
+            </div>
+            <div id="existing-maps-selection-container" style="display: none; margin-top: 15px;">
+                <h4>Select an existing map image:</h4>
+                <ul id="existing-maps-list-for-creation" style="list-style-type: none; padding: 0; max-height: 200px; overflow-y: auto; border: 1px solid #ccc;">
+                    <!-- Existing maps will be listed here -->
+                </ul>
             </div>
         </div>
     </div>

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -49,6 +49,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const uploadMapsInput = document.getElementById('upload-maps-input');
     const mapsList = document.getElementById('maps-list');
+    const createMapButton = document.getElementById('create-map-button');
+    const mapCreationContainer = document.getElementById('map-creation-container');
+    const mapCreationCanvas = document.getElementById('map-creation-canvas');
+    const uploadOrChooseBgButton = document.getElementById('upload-or-choose-bg-button');
+    const createMapModal = document.getElementById('create-map-modal');
+    const createMapModalCloseButton = document.getElementById('create-map-modal-close-button');
+    const uploadNewImageButton = document.getElementById('upload-new-image-button');
+    const chooseExistingImageButton = document.getElementById('choose-existing-image-button');
+    const newMapImageUpload = document.getElementById('new-map-image-upload');
+    const existingMapsSelectionContainer = document.getElementById('existing-maps-selection-container');
+    const existingMapsListForCreation = document.getElementById('existing-maps-list-for-creation');
     const openPlayerViewButton = document.getElementById('open-player-view-button'); // Added for player view
     const editMapsIcon = document.getElementById('edit-maps-icon');
     const dmCanvas = document.getElementById('dm-canvas');
@@ -568,6 +579,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Function to resize the canvas to fit its container
     function resizeCanvas() {
+        if (mapCreationCanvas && mapCreationContainer.style.display !== 'none') {
+            const style = window.getComputedStyle(mapCreationContainer);
+            const paddingLeft = parseFloat(style.paddingLeft) || 0;
+            const paddingRight = parseFloat(style.paddingRight) || 0;
+            const paddingTop = parseFloat(style.paddingTop) || 0;
+            const paddingBottom = parseFloat(style.paddingBottom) || 0;
+
+            const canvasWidth = mapCreationContainer.clientWidth - paddingLeft - paddingRight;
+            const canvasHeight = mapCreationContainer.clientHeight - paddingTop - paddingBottom;
+
+            mapCreationCanvas.width = canvasWidth;
+            mapCreationCanvas.height = canvasHeight;
+        }
+
         if (dmCanvas && drawingCanvas && mapContainer) {
             const style = window.getComputedStyle(mapContainer);
             const paddingLeft = parseFloat(style.paddingLeft) || 0;
@@ -2062,6 +2087,106 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     });
+
+    if (createMapButton) {
+        createMapButton.addEventListener('click', () => {
+            mapContainer.style.display = 'none';
+            mapCreationContainer.style.display = 'block';
+            resizeCanvas();
+        });
+    }
+
+    if (uploadOrChooseBgButton) {
+        uploadOrChooseBgButton.addEventListener('click', () => {
+            createMapModal.style.display = 'block';
+        });
+    }
+
+    if (createMapModalCloseButton) {
+        createMapModalCloseButton.addEventListener('click', () => {
+            createMapModal.style.display = 'none';
+        });
+    }
+
+    if (uploadNewImageButton) {
+        uploadNewImageButton.addEventListener('click', () => {
+            newMapImageUpload.click();
+        });
+    }
+
+    if (newMapImageUpload) {
+        newMapImageUpload.addEventListener('change', (event) => {
+            const file = event.target.files[0];
+            if (file) {
+                handleNewMapCreation(file.name, URL.createObjectURL(file));
+                createMapModal.style.display = 'none';
+            }
+        });
+    }
+
+    if (chooseExistingImageButton) {
+        chooseExistingImageButton.addEventListener('click', () => {
+            existingMapsListForCreation.innerHTML = '';
+            detailedMapData.forEach((mapData, mapName) => {
+                const listItem = document.createElement('li');
+                listItem.textContent = mapName;
+                listItem.dataset.mapName = mapName;
+                listItem.style.cursor = 'pointer';
+                existingMapsListForCreation.appendChild(listItem);
+            });
+            existingMapsSelectionContainer.style.display = 'block';
+        });
+    }
+
+    if (existingMapsListForCreation) {
+        existingMapsListForCreation.addEventListener('click', (event) => {
+            const mapName = event.target.dataset.mapName;
+            if (mapName) {
+                const mapData = detailedMapData.get(mapName);
+                if (mapData) {
+                    handleNewMapCreation(mapName, mapData.url, true);
+                    createMapModal.style.display = 'none';
+                    existingMapsSelectionContainer.style.display = 'none';
+                }
+            }
+        });
+    }
+
+    function handleNewMapCreation(baseName, url, isFromExisting = false) {
+        let newMapName = isFromExisting ? `${baseName} (copy)` : baseName;
+        let counter = 1;
+        while (detailedMapData.has(newMapName)) {
+            newMapName = isFromExisting ? `${baseName} (copy ${counter})` : `${baseName.split('.')[0]} (${counter}).${baseName.split('.')[1] || ''}`;
+            counter++;
+        }
+
+        detailedMapData.set(newMapName, {
+            url: url,
+            name: newMapName,
+            overlays: [],
+            mode: 'edit',
+            transform: { scale: 1, originX: 0, originY: 0, initialized: false }
+        });
+        displayedFileNames.add(newMapName);
+        renderMapsList();
+
+        mapCreationContainer.style.display = 'none';
+        mapContainer.style.display = 'block';
+
+        // Select and display the new map
+        selectedMapFileName = newMapName;
+        clearAllSelections();
+        const mapItems = mapsList.querySelectorAll('li');
+        mapItems.forEach(li => {
+            if (li.dataset.fileName === newMapName) {
+                li.classList.add('selected-map-item');
+            }
+        });
+        displayMapOnCanvas(newMapName);
+        updateButtonStates();
+        modeToggleSwitch.checked = false;
+        modeToggleSwitch.disabled = false;
+    }
 
     if (modeToggleSwitch) {
         modeToggleSwitch.addEventListener('change', () => {


### PR DESCRIPTION
This commit introduces a new 'Create Map' button in the DM Controls tab.

The new functionality allows the user to:
- Open a map creation view.
- Choose to upload a new background image or select from existing map images.
- Create a new map with the selected background, which is then added to the map list.

This feature is integrated with the existing save/load campaign functionality.