### PR TITLE
feat: Implement shadow drawing tool for walls and doors

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -489,6 +489,19 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+#shadow-tools-container {
+    display: flex;
+    gap: 10px;
+    padding: 10px;
+    background-color: rgba(42, 49, 56, 0.8);
+    border-radius: 5px;
+}
+
+#shadow-tools-container button.active {
+    background-color: #a0b4c9;
+    box-shadow: 0 0 8px rgba(182, 202, 225, 0.7);
+}
+
 /* Automation View Styles */
 #automation-container {
     display: flex;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -101,6 +101,11 @@
         </div>
     </div>
     <div id="map-container">
+        <div id="shadow-tools-container" style="display: none; position: absolute; top: 10px; left: 10px; z-index: 3;">
+            <button id="btn-draw-walls">Walls</button>
+            <button id="btn-draw-doors">Doors</button>
+            <button id="btn-shadow-done">Done</button>
+        </div>
         <canvas id="dm-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
     </div>
@@ -196,6 +201,7 @@
             <li data-action="link-character">Link Character</li>
             <li data-action="link-trigger">Link Trigger</li>
             <li data-action="remove-links">Remove Links</li>
+            <li data-action="shadow-tool">Shadows</li>
         </ul>
     </div>
 


### PR DESCRIPTION
Adds a new 'Shadows' tool to the map tools context menu in the DM view.

When activated, this tool provides three new options overlaid on the canvas: 'Walls', 'Doors', and 'Done'.

The 'Walls' tool allows the DM to draw multi-point, thick lines on the map to represent walls or other barriers. A left-click adds a point, and a right-click finalizes the current wall segment, allowing the user to immediately start drawing a new one.

The 'Doors' tool allows the DM to draw thick, black lines between two points to represent doors.

In the 'Active' map mode, these doors can be clicked to toggle their state between open and closed. Open doors are rendered as transparent for the DM and are not visible in the player view.

The new wall and door overlays are correctly saved and loaded with the campaign data.