### PR TITLE
feat: Add eraser tool and update cursors for shadow tools

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -104,6 +104,7 @@
         <div id="shadow-tools-container" style="display: none; position: absolute; top: 10px; left: 10px; z-index: 3;">
             <button id="btn-draw-walls">Walls</button>
             <button id="btn-draw-doors">Doors</button>
+            <button id="btn-erase-shadows">Erase</button>
             <button id="btn-shadow-done">Done</button>
         </div>
         <canvas id="dm-canvas"></canvas>


### PR DESCRIPTION
This commit enhances the recently added shadow drawing feature based on user feedback.

- Adds a new 'Erase' tool to the shadow tools overlay. When active, the cursor becomes a circle that deletes any wall or door segments it is dragged over.
- Changes the cursor to a 'crosshair' during wall and door drawing modes to provide better visual feedback for precision placement.
- Updates the state management logic to correctly handle the new 'Erase' mode alongside the existing 'Walls' and 'Doors' modes.