### PR TITLE
feat: Implement advanced shadow tool with line-of-sight

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -237,7 +237,7 @@ body.moving-mode {
     flex-direction: column; /* To make #note-editor-area inside it grow */
 }
 
-#dm-canvas, #drawing-canvas {
+#dm-canvas, #drawing-canvas, #shadow-canvas {
     position: absolute;
     max-width: 100%;
     max-height: 100%;
@@ -249,9 +249,15 @@ body.moving-mode {
     z-index: 1; /* Base canvas */
 }
 
+#shadow-canvas {
+    background-color: transparent;
+    z-index: 2; /* Shadow canvas on top of map */
+    pointer-events: none; /* Clicks pass through unless a shadow tool is active */
+}
+
 #drawing-canvas {
     background-color: transparent;
-    z-index: 2; /* Drawing canvas on top */
+    z-index: 3; /* UI/drawing canvas on top of shadows */
     pointer-events: none; /* Allows clicks to pass through to the dm-canvas */
 }
 button, input[type="file"] {

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -101,13 +101,15 @@
         </div>
     </div>
     <div id="map-container">
-        <div id="shadow-tools-container" style="display: none; position: absolute; top: 10px; left: 10px; z-index: 3;">
-            <button id="btn-draw-walls">Walls</button>
-            <button id="btn-draw-doors">Doors</button>
-            <button id="btn-erase-shadows">Erase</button>
+        <div id="shadow-tools-container" style="display: none; position: absolute; top: 10px; left: 10px; z-index: 4;">
+            <button id="btn-shadow-wall">Walls</button>
+            <button id="btn-shadow-door">Doors</button>
+            <button id="btn-add-light-source">Add Light Source</button>
+            <button id="btn-shadow-erase">Erase</button>
             <button id="btn-shadow-done">Done</button>
         </div>
         <canvas id="dm-canvas"></canvas>
+        <canvas id="shadow-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
     </div>
     <div id="automation-container" style="display: none; width: 100%;">


### PR DESCRIPTION
This commit refactors the existing shadow tool to use a more advanced line-of-sight shadow casting system.

The new shadow tool includes the following features:
- Line-of-sight visibility calculated from light sources.
- Tools for drawing walls (free-hand) and doors (lines).
- Ability to add and drag light sources on the map.
- An eraser tool to remove walls and doors.
- A 33% opaque shadow overlay for the DM's view.

The implementation is based on the user-provided example code and is integrated into the existing `dm_view` structure. The shadow data (walls, doors, light sources) is stored in the `overlays` array of the map data to ensure it is saved and loaded with the campaign.