### PR TITLE
feat: Implement advanced shadow and fog of war tool

### DIFF
--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -216,6 +216,7 @@
     </div>
     <div id="player-map-container">
         <canvas id="player-canvas"></canvas>
+        <canvas id="player-shadow-canvas" style="position: absolute; pointer-events: none;"></canvas>
         <div id="dice-roller-icon" class="absolute bottom-5 right-5 w-12 h-12 cursor-pointer z-10">
             <img src="assets/d20icon.png" alt="d20 icon" class="w-full h-full">
         </div>


### PR DESCRIPTION
This commit replaces the basic shadow drawing tool with a more advanced system that provides a "fog of war" effect using line-of-sight calculations.

Key features:
- A new `shadow-canvas` is added to both DM and player views to render dynamic shadows.
- DMs can now use a new set of tools to:
  - Draw walls (free-draw) and doors (lines).
  - Add and move light sources.
  - Erase any of the above elements.
- Shadows are dynamically calculated based on the positions of light sources, walls, and doors.
- The DM sees a 33% opaque shadow overlay, while the player sees a 100% opaque overlay.
- In the player view, character tokens also act as light sources, revealing the area around them.
- The shadow effect is only active when the map is in "view" mode.

This implementation addresses all user feedback, including fixing UI/UX issues with the drawing tools and ensuring the player view is correctly updated.