### PR TITLE
fix: Correct eraser functionality and resolve console errors

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1497,8 +1497,9 @@ document.addEventListener('DOMContentLoaded', () => {
                             }
                         }
                     } else if (overlay.type === 'lightSource') {
+                        const lightRadius = (overlay.radius || 15) / (currentMapDisplayData.scale || 1);
                         const distance = Math.sqrt((mouseX - overlay.position.x)**2 + (mouseY - overlay.position.y)**2);
-                        if (distance < eraserRadius) {
+                        if (distance < eraserRadius + lightRadius) {
                             mapData.overlays.splice(i, 1);
                             changed = true;
                         }
@@ -2544,8 +2545,8 @@ document.addEventListener('DOMContentLoaded', () => {
         mapContainer.addEventListener('mousedown', (e) => {
             if (e.button !== 0) return;
 
-            if (isErasing) {
-                isEraserDragging = true;
+            if (activeShadowTool === 'erase') {
+                isDrawing = true;
                 e.preventDefault(); // Prevent other actions like panning
                 return;
             }
@@ -2608,8 +2609,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         mapContainer.addEventListener('mouseup', (e) => {
             if (e.button !== 0) return;
-            if (isErasing) {
-                isEraserDragging = false;
+            if (activeShadowTool === 'erase') {
+                isDrawing = false;
             }
             isPanning = false;
             mapContainer.style.cursor = 'grab';


### PR DESCRIPTION
This commit addresses two issues found after the initial implementation of the advanced shadow tool:

1. A `ReferenceError` for the undefined variable `isErasing` was thrown when using the eraser tool. This has been fixed by replacing it with the correct state check (`activeShadowTool === 'erase'`).

2. The eraser tool was not able to erase light sources. The collision detection logic has been improved to correctly identify and remove light sources when the eraser is used on them.