### PR TITLE
fix: Disable map panning and improve tool deactivation

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1381,6 +1381,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const mapData = detailedMapData.get(selectedMapFileName);
         if (!mapData) return;
 
+        if (activeShadowTool) {
+            e.stopPropagation();
+        }
+
         if (!activeShadowTool) {
             const lightSources = mapData.overlays.filter(o => o.type === 'lightSource');
             for (let i = lightSources.length - 1; i >= 0; i--) {
@@ -1989,6 +1993,11 @@ document.addEventListener('DOMContentLoaded', () => {
         drawingCtx.clearRect(0, 0, drawingCanvas.width, drawingCanvas.height);
         drawingCanvas.style.pointerEvents = 'none';
         dmCanvas.style.cursor = 'auto';
+
+        if (activeShadowTool) {
+            setShadowTool(null);
+        }
+
         selectedPolygonForContextMenu = null;
         selectedNoteForContextMenu = null;
         selectedCharacterForContextMenu = null;
@@ -2524,6 +2533,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 displayMapOnCanvas(selectedMapFileName);
                 updateButtonStates();
                 if (selectedMapData.mode === 'view') {
+                    if (activeShadowTool) {
+                        setShadowTool(null);
+                    }
                     sendMapToPlayerView(selectedMapFileName);
                     toggleShadowAnimation(true);
                 } else {


### PR DESCRIPTION
This commit addresses UI issues related to the advanced shadow tool:

1. Map panning is now disabled when a shadow tool is active. This is achieved by stopping event propagation from the shadow canvas to the map container.
2. The active shadow tool is now automatically deactivated when the user's context changes, such as:
    - Switching to a different map.
    - Selecting a non-shadow tool (e.g., "Link Note").
    - Changing the map mode to "view".