### PR TITLE
feat: Add interactive doors for dynamic vision control

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -137,7 +137,7 @@ function animateShadows() {
     }));
 
     const lightSources = [...dmLightSources, ...tokenLightSources];
-    const shadowLines = currentOverlays.filter(o => o.type === 'wall' || o.type === 'door');
+    const shadowLines = currentOverlays.filter(o => o.type === 'wall' || (o.type === 'door' && !o.isOpen));
 
     const shadowCtx = shadowCanvas.getContext('2d');
     shadowCanvas.width = playerCanvas.width;


### PR DESCRIPTION
This commit introduces interactive doors to the shadow tool system.

- Doors now have an `isOpen` state, which defaults to `false`.
- In 'view' mode, the DM can click on a door to toggle its state between open and closed.
- Open doors no longer cast shadows, and the vision cone updates instantly for both the DM and players.
- A visual indicator has been added: open doors are drawn as a dashed green line, while closed doors are a solid red line.