### PR TITLE
feat: Implement character visibility feature

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -548,20 +548,30 @@ window.addEventListener('message', (event) => {
                 const diceDialogueRecord = document.getElementById('dice-dialogue-record');
                 if (diceDialogueRecord) {
                     diceDialogueRecord.style.display = data.isOpen ? 'flex' : 'none';
-                    if(data.isOpen) {
+                    if (data.isOpen) {
                         diceDialogueRecord.classList.add('persistent-log');
-                        diceDialogueRecord.innerHTML = data.content;
-                         if (!document.getElementById('action-log-minimize-button')) {
+                        diceDialogueRecord.innerHTML = ''; // Clear content
+
+                        if (!diceDialogueRecord.querySelector('.overlay-minimize-button')) {
                             const minimizeButton = document.createElement('button');
-                            minimizeButton.id = 'action-log-minimize-button';
+                            minimizeButton.className = 'overlay-minimize-button';
                             minimizeButton.textContent = '—';
                             minimizeButton.onclick = () => {
                                 diceDialogueRecord.classList.remove('persistent-log');
                                 diceDialogueRecord.style.display = 'none';
-                                const btn = document.getElementById('action-log-minimize-button');
-                                if(btn) btn.remove();
                             };
                             diceDialogueRecord.prepend(minimizeButton);
+                        }
+
+                        if (data.history) {
+                            data.history.forEach(logEntry => {
+                                const card = createLogCard(logEntry);
+                                if (diceDialogueRecord.firstChild) {
+                                    diceDialogueRecord.insertBefore(card, diceDialogueRecord.firstChild.nextSibling);
+                                } else {
+                                    diceDialogueRecord.appendChild(card);
+                                }
+                            });
                         }
                     } else {
                         diceDialogueRecord.classList.remove('persistent-log');


### PR DESCRIPTION
This commit introduces a character visibility feature that allows the DM to hide character details from the player's view.

Key changes:
- A `censorCharacterDataForPlayerView` helper function is added to `dm_view.js` to redact character information (name, stats, portrait, etc.) if their `isDetailsVisible` flag is set to false.
- This censoring function is now applied to all data sent to the player view, including:
  - Initiative tracker lists and map tokens
  - Token stat blocks
  - Action log toasts and the persistent action log
- The action log communication protocol between the DM and player views has been refactored to send structured data (`diceRollHistory` array) instead of raw HTML. This makes censoring more robust and secure.
- The `player_view.js` has been updated to handle the new structured data for the action log, dynamically creating log cards from the received history.