### PR TITLE
feat: Prevent invisible tokens from providing vision

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6725,7 +6725,8 @@ function displayToast(messageElement) {
                         name: character.name,
                         playerName: character.sheetData.player_name,
                         portrait: character.sheetData.character_portrait,
-                        initials: getInitials(character.name)
+                        initials: getInitials(character.name),
+                        isDetailsVisible: character.isDetailsVisible
                     };
                     initiativeTokens.push(token);
                     tokenX += tokenPixelSize + 10;
@@ -6824,7 +6825,8 @@ function displayToast(messageElement) {
                         name: character.name,
                         playerName: character.sheetData.player_name,
                         portrait: character.sheetData.character_portrait,
-                        initials: getInitials(character.name)
+                        initials: getInitials(character.name),
+                        isDetailsVisible: character.isDetailsVisible
                     };
                     initiativeTokens.push(token);
                     tokenX += tokenPixelSize + 10;

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -130,10 +130,12 @@ function animateShadows() {
     if (!shadowAnimationId) return;
 
     const dmLightSources = currentOverlays.filter(o => o.type === 'lightSource');
-    const tokenLightSources = initiativeTokens.map(token => ({
-        type: 'lightSource',
-        position: { x: token.x, y: token.y },
-        radius: 60 // Default vision radius for tokens
+    const tokenLightSources = initiativeTokens
+        .filter(token => token.isDetailsVisible !== false) // Only visible tokens are light sources
+        .map(token => ({
+            type: 'lightSource',
+            position: { x: token.x, y: token.y },
+            radius: 60 // Default vision radius for tokens
     }));
 
     const lightSources = [...dmLightSources, ...tokenLightSources];


### PR DESCRIPTION
This commit builds on the character visibility feature by ensuring that tokens for invisible characters do not act as light sources in the player's view.

- The `dm_view.js` file is updated to include the `isDetailsVisible` property in the data for each map token.
- The `player_view.js` file's `animateShadows` function is updated to filter out any tokens where `isDetailsVisible` is false before calculating light sources for the fog of war.