### PR TITLE
feat: Optimize canvas performance and add quality sliders

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -371,6 +371,16 @@
                             <input type="range" id="map-icon-size-slider" min="1" max="20" value="5">
                             <span id="map-icon-size-value">5%</span>
                         </div>
+                        <div class="setting-item">
+                            <label for="dm-render-quality-slider">DM Render Quality</label>
+                            <input type="range" id="dm-render-quality-slider" min="0.1" max="1.0" step="0.1" value="0.5">
+                            <span id="dm-render-quality-value">0.5</span>
+                        </div>
+                        <div class="setting-item">
+                            <label for="player-render-quality-slider">Player Render Quality</label>
+                            <input type="range" id="player-render-quality-slider" min="0.1" max="1.0" step="0.1" value="0.5">
+                            <span id="player-render-quality-value">0.5</span>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This commit introduces significant performance improvements for the three main canvases: the DM map, the Player view map, and the Story Beats Tree.

The primary optimization is for the dynamic lighting and shadow system. The expensive ray-casting and geometry calculations are no longer performed on every animation frame. Instead, a lower-resolution "light map" is pre-rendered to an off-screen canvas. This light map is only recalculated when a light source or shadow-casting object changes. The main animation loop now only performs a single, fast `drawImage` operation to render the lighting, resulting in a much smoother experience, especially during panning and zooming.

To give users control over this new system, two rendering quality sliders have been added to the Initiative Tracker settings. These allow the DM to independently control the resolution of the light map for their own view and for the player's view, balancing performance and visual quality. These settings are now saved and loaded with the campaign.

Additionally, the pan and zoom functionality for the Story Beats Tree has been refactored to use hardware-accelerated CSS transforms instead of redrawing on the canvas, which makes navigating a large story tree much more responsive.