### PR TITLE
feat: Implement automation card functionality

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -582,6 +582,10 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #e0e0e0;
 }
 
+#automation-canvas .module-card {
+    cursor: default;
+}
+
 .quest-footer-card {
     padding: 8px 12px;
     background-color: #3a4f6a;


### PR DESCRIPTION
This commit introduces functionality to the 'Automation' tab in the Story Beats section.

- The buttons in the 'modules' sidebar now act as card templates.
- Clicking a button creates a visually identical card (including color and title) on the central canvas.
- The state of the automation canvas is now saved and loaded with the campaign data, ensuring persistence across sessions.
- Older campaign files without this new data can still be loaded without error.
- The cursor for cards on the canvas is now correctly set to 'default' to indicate they are not interactive.