### PR TITLE
This commit introduces new functionality to the "Automation" view in …

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -583,7 +583,18 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 }
 
 #automation-canvas .module-card {
+    position: relative; /* Needed for absolute positioning of the label */
     cursor: default;
+}
+
+.automation-card-label {
+    position: absolute;
+    bottom: 5px;
+    right: 8px;
+    font-size: 11px;
+    font-weight: normal;
+    color: #a0b4c9;
+    font-style: italic;
 }
 
 .quest-footer-card {


### PR DESCRIPTION
…the "Story Beats" tab.

Key features include:
- Clicking a module button in the sidebar now adds a visually identical card to the central canvas, correctly copying its color (which is determined by the DM/Both toggle).
- Each card added to the canvas receives a small, unique label in the bottom-right corner, formatted as `{{card_title}}_{{instance_count}}`.
- The campaign save/load functionality has been updated to persist the state of the automation canvas, including all cards, their colors, and their unique labels. This change is backward compatible with older save files.
- Added CSS to style the new labels appropriately.