### PR TITLE
feat: Add visual selection for active automation card

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -495,6 +495,11 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.module-card.automation-card-selected {
+    box-shadow: 0 0 0 3px #4A90E2, 0 5px 15px rgba(0,0,0,0.3);
+    transform: scale(1.05);
+}
+
 #shadow-tools-container {
     display: flex;
     gap: 10px;

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7463,6 +7463,15 @@ function displayToast(messageElement) {
     }
 
 function displayCardDetails(cardElement) {
+    // Clear previous selection
+    const automationCanvas = document.getElementById('automation-canvas');
+    if (automationCanvas) {
+        const allCards = automationCanvas.querySelectorAll('.module-card');
+        allCards.forEach(card => card.classList.remove('automation-card-selected'));
+    }
+    // Add selection to current card
+    cardElement.classList.add('automation-card-selected');
+
     const detailsSidebar = document.getElementById('details-sidebar');
     detailsSidebar.innerHTML = ''; // Clear previous content
 


### PR DESCRIPTION
This commit introduces a visual selection indicator for cards on the automation canvas.

- Adds a new CSS class `.automation-card-selected` to provide a clear visual highlight (border and shadow).
- Modifies the `displayCardDetails` function to manage the selected state. When a card is clicked, it gains the 'selected' class, and any previously selected card has the class removed.
- This improves the user experience by making it clear which card's details are currently displayed in the sidebar.