### PR TITLE
feat: Make automation cards draggable

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -500,6 +500,10 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     transform: scale(1.05);
 }
 
+#automation-canvas .module-card.dragging {
+    opacity: 0.5;
+}
+
 #shadow-tools-container {
     display: flex;
     gap: 10px;

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7446,6 +7446,14 @@ function displayToast(messageElement) {
                 displayCardDetails(card);
             });
 
+            card.draggable = true;
+            card.addEventListener('dragstart', () => {
+                card.classList.add('dragging');
+            });
+            card.addEventListener('dragend', () => {
+                card.classList.remove('dragging');
+            });
+
             // Update counters based on loaded data
             const labelSpan = card.querySelector('.automation-card-label');
             if (labelSpan) {
@@ -7570,6 +7578,20 @@ function displayCardDetails(cardElement) {
     detailsSidebar.appendChild(deleteButton);
 }
 
+function getDragAfterElement(container, y) {
+    const draggableElements = [...container.querySelectorAll('.module-card:not(.dragging)')];
+
+    return draggableElements.reduce((closest, child) => {
+        const box = child.getBoundingClientRect();
+        const offset = y - box.top - box.height / 2;
+        if (offset < 0 && offset > closest.offset) {
+            return { offset: offset, element: child };
+        } else {
+            return closest;
+        }
+    }, { offset: Number.NEGATIVE_INFINITY }).element;
+}
+
     function initializeAutomationSidebar() {
         const moduleCardsContainer = document.getElementById('module-cards-container');
         const automationCanvas = document.getElementById('automation-canvas');
@@ -7614,9 +7636,30 @@ function displayCardDetails(cardElement) {
                     displayCardDetails(newCard);
                 });
 
+                newCard.draggable = true;
+                newCard.addEventListener('dragstart', () => {
+                    newCard.classList.add('dragging');
+                });
+                newCard.addEventListener('dragend', () => {
+                    newCard.classList.remove('dragging');
+                });
+
                 automationCanvas.appendChild(newCard);
             });
             moduleCardsContainer.appendChild(card);
+        });
+
+        automationCanvas.addEventListener('dragover', event => {
+            event.preventDefault();
+            const afterElement = getDragAfterElement(automationCanvas, event.clientY);
+            const draggingCard = document.querySelector('#automation-canvas .module-card.dragging');
+            if (draggingCard) {
+                if (afterElement == null) {
+                    automationCanvas.appendChild(draggingCard);
+                } else {
+                    automationCanvas.insertBefore(draggingCard, afterElement);
+                }
+            }
         });
 
         updateCardColors(toggleSwitch.checked);


### PR DESCRIPTION
This commit implements drag-and-drop reordering for cards on the automation canvas.

- The `draggable` attribute is now set to true for all cards.
- `dragstart` and `dragend` event listeners are added to each card to toggle a `.dragging` CSS class for visual feedback.
- A `dragover` event listener is added to the main `automationCanvas` container. This listener determines the card's new position based on the cursor's location and reorders the DOM elements in real-time using `insertBefore`.
- A helper function, `getDragAfterElement`, has been added to calculate the correct insertion point.
- The new order is persisted automatically by the existing save/load logic, which saves the DOM elements in their current order.