### PR TITLE
feat(story-beats): Improve note linking UI

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -495,6 +495,78 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* Styles for Automation Note Linking in Details Sidebar */
+.available-notes-container {
+    background-color: #15191e;
+    border: 1px solid #3f4c5a;
+    border-radius: 4px;
+    padding: 5px;
+    max-height: 200px;
+    overflow-y: auto;
+    margin-top: 10px;
+}
+
+.available-note-item {
+    padding: 8px;
+    margin: 2px 0;
+    background-color: #2a3138;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.available-note-item:hover {
+    background-color: #3f4c5a;
+    color: #b6cae1;
+}
+
+.automation-linked-notes-list {
+    list-style-type: decimal; /* Use numbers for the ordered list */
+    padding-left: 20px; /* Standard padding for ordered lists */
+    margin-top: 5px;
+}
+
+.linked-note-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px 0;
+    margin-bottom: 2px;
+}
+
+.linked-note-item a {
+    color: #8ab4f8;
+    text-decoration: none;
+    flex-grow: 1;
+}
+
+.linked-note-item a:hover {
+    text-decoration: underline;
+}
+
+.remove-note-link-btn {
+    background: none;
+    border: none;
+    color: #ff4d4d;
+    font-size: 18px;
+    font-weight: bold;
+    cursor: pointer;
+    padding: 0 5px;
+    line-height: 1;
+}
+
+.remove-note-link-btn:hover {
+    color: #ff8a8a;
+}
+
+.sidebar-placeholder {
+    color: #8c96a2;
+    font-style: italic;
+    font-size: 0.9em;
+    padding: 10px;
+    text-align: center;
+}
+
 .module-card.automation-card-selected {
     box-shadow: 0 0 0 3px #4A90E2, 0 5px 15px rgba(0,0,0,0.3);
     transform: scale(1.05);


### PR DESCRIPTION
This commit refactors the note linking functionality in the Story Beats automation view.

Previously, linking a note to a story beat card required navigating to the Notes tab. This commit introduces a new UI within the details sidebar of the automation view, allowing users to link and unlink notes without leaving the Story Beats tab.

Changes include:
- The `displayCardDetails` function in `dm_view.js` has been updated to show a new interface for note cards.
- The new interface displays a scrollable list of available notes and a list of currently linked notes.
- Users can now click on available notes to link them and click a "remove" button to unlink them.
- Supporting CSS has been added to `dm_view.css` for the new UI elements.
- The save/load functionality has been verified to correctly handle the new linked notes data, which is stored in the card's dataset.