### PR TITLE
Extend DM Only/Both interaction mode to note and character cards

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -7552,9 +7552,22 @@ function displayCardDetails(cardElement) {
                         e.preventDefault();
                         const notePreviewOverlay = document.getElementById('note-preview-overlay');
                         const notePreviewBody = document.getElementById('note-preview-body');
+                        const interactionMode = cardElement.dataset.interactionMode;
+
                         if (notePreviewOverlay && notePreviewBody && easyMDE) {
+                            // Show DM preview regardless of mode
                             notePreviewBody.innerHTML = easyMDE.options.previewRender(note.content);
                             notePreviewOverlay.style.display = 'flex';
+
+                            // If mode is 'both', also send to player
+                            if (interactionMode === 'both' && playerWindow && !playerWindow.closed) {
+                                const playerNoteContent = filterPlayerContent(note.content);
+                                const playerRenderedHTML = easyMDE.options.previewRender(playerNoteContent);
+                                playerWindow.postMessage({
+                                    type: 'showNotePreview',
+                                    content: playerRenderedHTML
+                                }, '*');
+                            }
                         }
                     });
 
@@ -7644,10 +7657,22 @@ function displayCardDetails(cardElement) {
                         e.preventDefault();
                         const charPreviewOverlay = document.getElementById('character-preview-overlay');
                         const charPreviewBody = document.getElementById('character-preview-body');
+                        const interactionMode = cardElement.dataset.interactionMode;
+
                         if (charPreviewOverlay && charPreviewBody) {
-                            const markdown = generateCharacterMarkdown(character.sheetData, character.notes, false, character.isDetailsVisible);
-                            charPreviewBody.innerHTML = markdown;
+                            // Show DM preview regardless of mode
+                            const dmMarkdown = generateCharacterMarkdown(character.sheetData, character.notes, false, character.isDetailsVisible);
+                            charPreviewBody.innerHTML = dmMarkdown;
                             charPreviewOverlay.style.display = 'flex';
+
+                            // If mode is 'both', also send to player
+                            if (interactionMode === 'both' && playerWindow && !playerWindow.closed) {
+                                const playerMarkdown = generateCharacterMarkdown(character.sheetData, character.notes, true, character.isDetailsVisible);
+                                playerWindow.postMessage({
+                                    type: 'showCharacterPreview',
+                                    content: playerMarkdown
+                                }, '*');
+                            }
                         }
                     });
 


### PR DESCRIPTION
This commit expands the functionality of the "DM Only / Both" toggle on the automation canvas sidebar to include note and character cards.

Previously, this feature only applied to map cards. Now, when a note or character card is created, its `interactionMode` is stored in its dataset.

The click handlers within the details pane for linked notes and characters have been updated to check this `interactionMode`.
- If the mode is 'dm-only', clicking a link will only open the preview overlay for the DM.
- If the mode is 'both', clicking a link will open the preview for the DM and simultaneously send the relevant, player-safe content to the player's view. This maintains content privacy by stripping DM-only sections from notes and censoring character sheets as needed.