### PR TITLE
Fix: Adjust DM footer height to prevent overflow

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -1107,21 +1107,23 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 /* New Floating Footer Styles */
 #dm-floating-footer {
     position: fixed;
-    bottom: -30vh; /* Initially hidden */
+    bottom: 0;
     left: 0;
     width: 100%;
     background-color: #20262d;
     border-top: 1px solid #3f4c5a;
     box-sizing: border-box;
     z-index: 1002;
-    transition: bottom 0.3s ease-in-out;
+    transition: transform 0.3s ease-in-out;
     display: flex;
     flex-direction: column;
-    height: 30vh;
+    max-height: 45vh;
+    transform: translateY(100%);
+    overflow: hidden;
 }
 
 #dm-floating-footer.visible {
-    bottom: 0;
+    transform: translateY(0);
 }
 
 #footer-content-wrapper {


### PR DESCRIPTION
The DM floating footer had a fixed height of 30vh, which caused its content to be cut off when the 'Quests' tab was selected, as this tab's content could exceed the fixed height.

This change modifies the footer's CSS to:
- Remove the fixed `height` property.
- Use `max-height` to allow the footer to grow with its content up to a reasonable limit (45vh).
- Change the animation from using the `bottom` property to using `transform: translateY()` for hiding and showing the footer. This allows the animation to work correctly with a dynamic height.
- The transition property was updated accordingly.

This ensures the footer always opens to the appropriate height to display all its content without being cut off.