### PR TITLE
Fix: Invisible duplicate tokens now correctly hide their vision.

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -633,6 +633,11 @@ let linkingNoteForAutomationCard = null;
             }
         }
 
+    // Ensure the visibility flag is correctly set for the player view's logic
+    if ('isDetailsVisible' in censoredCharacter) {
+        censoredCharacter.isDetailsVisible = false;
+    }
+
         return censoredCharacter;
     }
 


### PR DESCRIPTION
The `censorCharacterDataForPlayerView` function was correctly censoring character details like name and portrait for invisible characters, but it was not setting the `isDetailsVisible` flag to `false` on the data sent to the player view.

This meant that the player view would receive tokens with censored details but with `isDetailsVisible: true`, causing it to incorrectly render a light source for them.

The fix ensures that `isDetailsVisible` is explicitly set to `false` on censored character objects, resolving the bug.