### PR TITLE
This commit introduces a 'smart shadow' tool to the DM controls.

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -103,6 +103,7 @@
     </div>
     <div id="map-container">
         <div id="shadow-tools-container" style="display: none; position: absolute; top: 10px; left: 10px; z-index: 4;">
+            <button id="btn-shadow-object">Objects</button>
             <button id="btn-shadow-wall">Walls</button>
             <button id="btn-shadow-door">Doors</button>
             <button id="btn-add-light-source">Add Light Source</button>


### PR DESCRIPTION
A new 'Objects' button has been added to the shadow toolbar, allowing the DM to draw polygons representing map objects like pillars or furniture.

These 'smart objects' have unique lighting properties:
- They become fully illuminated when struck by a light source.
- They simultaneously cast a shadow behind them, away from the light source.

This allows for more dynamic and realistic lighting on maps with complex environments.

The implementation includes:
- A new 'Objects' button in `dm_view.html`.
- State management and drawing logic for the new tool in `dm_view.js`.
- A completely reworked `recalculateLightMap` function to handle the new lighting and shadow-casting behavior for these objects.
- Updates to the `drawOverlays` function to render the objects in edit mode.
- Updates to the eraser tool to allow for the deletion of these objects.

The new `smart_object` overlay type is integrated into the existing save/load system and is fully backward-compatible with older campaign files.