### PR TITLE
Fix: Unify shadow and lighting logic for DM and Player views

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1410,7 +1410,15 @@ function propagateCharacterUpdate(characterId) {
             lightMapCtx = lightMapCanvas.getContext('2d');
         }
 
-        const lightSources = mapData.overlays.filter(o => o.type === 'lightSource');
+        const dmLightSources = mapData.overlays.filter(o => o.type === 'lightSource');
+        const tokenLightSources = initiativeTokens
+            .filter(token => token.isDetailsVisible !== false)
+            .map(token => ({
+                type: 'lightSource',
+                position: { x: token.x, y: token.y },
+                radius: 40 // A reasonable default radius for a token
+            }));
+        const lightSources = [...dmLightSources, ...tokenLightSources];
         const walls = mapData.overlays.filter(o => o.type === 'wall');
         const closedDoors = mapData.overlays.filter(o => o.type === 'door' && !o.isOpen);
         const smartObjects = mapData.overlays.filter(o => o.type === 'smart_object');


### PR DESCRIPTION
This commit addresses two critical bugs in the shadow and lighting system:
1.  **Player View Shadows:** The player view was using an outdated lighting engine that did not render one-way "Object" shadows correctly. This has been fixed by replacing the player's lighting logic with the modern engine from the DM's view.
2.  **Token Light Sources:** Character tokens in the initiative tracker were not casting light or shadows in either the DM or Player views. Both views now correctly treat visible tokens as light sources.

Key changes include:
- Updating `player_view.js` with the correct `recalculateLightMap` function and its helpers (`getLineIntersection`, `isPointInPolygon`, `getPolygonSignedArea`).
- Adding logic to `dm_view.js` to include initiative tokens as light sources.
- Ensuring backward compatibility by adding checks to correctly orient "Object" polygons from older campaign save files.