### PR TITLE
feat: Add titles to story steps and implement action logs

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -495,6 +495,22 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+.story-step-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 5px;
+}
+
+.story-step-title {
+    font-weight: bold;
+}
+
+.story-step-text {
+    font-size: 0.9em;
+    color: #a0b4c9;
+}
+
 /* Styles for Automation Note Linking in Details Sidebar */
 .available-notes-container {
     background-color: #15191e;


### PR DESCRIPTION
This commit introduces two main features:

1.  **Story Step Titles:**
    - Each story step within a quest now has an editable title in addition to its description.
    - The quest details overlay has been updated to reflect this change, with separate fields for title and description.
    - This change is backward compatible with older save files; if a title is not present, the description is used as the title.

2.  **Action Log for Quests:**
    - Action log entries are now automatically generated for quest-related events.
    - A log entry is created when a quest's status is changed (e.g., "Quest Name Available").
    - A log entry is created when a story step is completed for an active quest (e.g., "Quest Name: Step Title").