### PR TITLE
Fix: Make story step title a click-to-edit h3

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -8825,30 +8825,6 @@ function getDragAfterElement(container, y) {
         overlay.style.display = 'flex';
         activeOverlayCardId = quest.id;
 
-        // --- Click to Edit for Story Step Titles ---
-        const storyStepsContainer = document.getElementById('quest-story-steps');
-        if (storyStepsContainer) {
-            storyStepsContainer.addEventListener('click', (e) => {
-                const titleEl = e.target.closest('.story-step-title');
-                if (titleEl && !titleEl.isContentEditable) {
-                    titleEl.contentEditable = true;
-                    titleEl.focus();
-                    const range = document.createRange();
-                    range.selectNodeContents(titleEl);
-                    const sel = window.getSelection();
-                    sel.removeAllRanges();
-                    sel.addRange(range);
-                }
-            });
-
-            storyStepsContainer.addEventListener('blur', (e) => {
-                const titleEl = e.target.closest('.story-step-title');
-                if (titleEl) {
-                    titleEl.contentEditable = false;
-                }
-            }, true); // Use capture phase
-        }
-
         // --- Event Listeners for editing ---
         const saveButton = document.getElementById('save-quest-details-btn');
         saveButton.addEventListener('click', () => {
@@ -8980,7 +8956,25 @@ function getDragAfterElement(container, y) {
             if (e.target.classList.contains('remove-step-btn')) {
                 e.target.closest('.story-step-row').remove();
             }
+
+            const titleEl = e.target.closest('.story-step-title');
+            if (titleEl && !titleEl.isContentEditable) {
+                titleEl.contentEditable = true;
+                titleEl.focus();
+                const range = document.createRange();
+                range.selectNodeContents(titleEl);
+                const sel = window.getSelection();
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
         });
+
+        storyStepsContainer.addEventListener('blur', (e) => {
+            const titleEl = e.target.closest('.story-step-title');
+            if (titleEl) {
+                titleEl.contentEditable = false;
+            }
+        }, true);
 
         storyStepsContainer.addEventListener('change', e => {
             if (e.target.classList.contains('story-step-checkbox') && e.target.checked) {


### PR DESCRIPTION
This addresses a backward-compatibility issue where older save files without a `title` field for story steps would fail to load correctly.

The story step title is converted from a `div` to an `h3` element. Click-to-edit functionality is added to the `h3` title, mimicking the behavior of the main quest title. A hover effect is added to the title to indicate it's editable.

The `mergeCampaignData` function is updated to gracefully handle old save formats by creating a default title (e.g., "Step 1") and preserving the existing text as the description.

This also resolves a `SyntaxError` from a previous attempt caused by a redeclared variable.