### PR TITLE
feat: Add Assets tool for DM view with file explorer and favorites

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2642,7 +2642,7 @@ function propagateCharacterUpdate(characterId) {
             } else if (item.type === 'file') {
                 const isFavorite = assetFavorites[item.path];
                 assetItemDiv.innerHTML = `
-                    <button class="asset-favorite-btn ${isFavorite ? 'is-favorite' : ''}" title="Toggle Favorite">⭐</button>
+                    <button class="asset-favorite-btn ${isFavorite ? 'is-favorite' : ''}" title="Toggle Favorite">${isFavorite ? '⭐' : '⚪'}</button>
                     <img src="${item.url}" alt="${name}">
                     <span class="asset-name">${name}</span>
                 `;
@@ -2673,8 +2673,6 @@ function propagateCharacterUpdate(characterId) {
     function handleAssetFolderUpload(event) {
         const files = event.target.files;
         if (!files.length) return;
-
-        assetsByPath = {}; // Reset
 
         for (const file of files) {
             // We only care about images


### PR DESCRIPTION
This commit introduces a new 'Assets' tool to the DM view, providing a comprehensive solution for managing image assets within a campaign.

Key Features:
- **Assets Tool Activation**: A new 'Assets' option in the right-click context menu on the map activates the tool, revealing an overlay and a dedicated 'Assets' tab in the footer.
- **Asset Explorer**: The 'Assets' footer tab contains a file explorer that allows users to upload entire folders of images. It supports nested folder structures and displays image previews.
- **Favorites System**: Users can mark individual assets as favorites. A 'Favorites' folder at the root of the explorer provides quick access to all bookmarked items. The icons for favorited (⭐) and unfavorited (⚪) items are distinct for clarity.
- **UI/UX Improvements**:
  - The asset footer remains open during interaction, only closing when intended.
  - Selected assets receive a visual 'glow' effect for clear identification.
  - Uploading new asset folders now correctly appends them to the library instead of replacing existing assets.
- **Save/Load Integration**: The entire asset library, including the file structure and the list of favorites, is saved and loaded as part of the campaign `.zip` file, ensuring data persistence across sessions.