### PR TITLE
feat: Implement asset placement from footer

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -555,8 +555,8 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 }
 
 .asset-item.selected {
-    border-color: #4d90fe;
-    box-shadow: 0 0 8px 2px #4d90fe;
+    border-color: #8ab4f8;
+    box-shadow: 0 0 12px 4px rgba(138, 180, 248, 0.7);
 }
 
 .asset-item img {


### PR DESCRIPTION
This commit introduces a new feature allowing users to place assets onto the map canvas directly from the asset explorer in the footer.

Key features include:
- Visual feedback (a "glow" effect) for the selected asset in the footer.
- A semi-transparent preview of the selected asset that follows the mouse cursor over the canvas.
- The ability to place the asset onto the map at full opacity with a single click.
- Deselection of an asset by clicking it again.
- Caching of asset images to improve performance when drawing and previewing.
- Integration with the existing save/load system by adding placed assets to the map's overlay data.