### PR TITLE
fix: Prevent asset preview from clearing placed assets

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2735,6 +2735,13 @@ function propagateCharacterUpdate(characterId) {
     function handleAssetPreviewMouseMove(event) {
         if (!selectedAssetForPreview || !selectedAssetForPreview.complete) return;
 
+        const selectedMapData = detailedMapData.get(selectedMapFileName);
+        if (!selectedMapData) return;
+
+        // Redraw existing overlays. This also clears the canvas.
+        drawOverlays(selectedMapData.overlays);
+
+        // Now, draw the preview on top.
         const drawingCtx = drawingCanvas.getContext('2d');
         const rect = dmCanvas.getBoundingClientRect();
         const canvasX = event.clientX - rect.left;
@@ -2754,7 +2761,6 @@ function propagateCharacterUpdate(characterId) {
             }
         }
 
-        drawingCtx.clearRect(0, 0, drawingCanvas.width, drawingCanvas.height);
         drawingCtx.globalAlpha = 0.33;
 
         // Draw the image centered on the cursor
@@ -2764,8 +2770,13 @@ function propagateCharacterUpdate(characterId) {
     }
 
     function handleAssetPreviewMouseOut() {
-        const drawingCtx = drawingCanvas.getContext('2d');
-        drawingCtx.clearRect(0, 0, drawingCanvas.width, drawingCanvas.height);
+        const selectedMapData = detailedMapData.get(selectedMapFileName);
+        if (selectedMapData) {
+            drawOverlays(selectedMapData.overlays);
+        } else {
+            const drawingCtx = drawingCanvas.getContext('2d');
+            drawingCtx.clearRect(0, 0, drawingCanvas.width, drawingCanvas.height);
+        }
     }
 
     function updateAssetPreview() {


### PR DESCRIPTION
This commit fixes a bug where moving the mouse while an asset was selected for preview would clear any previously placed assets from the canvas.

The `handleAssetPreviewMouseMove` function was incorrectly clearing the entire `drawingCanvas` before drawing the preview. This has been changed to first call `drawOverlays` to render all existing overlays, and then draw the preview on top.

Additionally, `handleAssetPreviewMouseOut` has been updated to also call `drawOverlays` to ensure the canvas is correctly redrawn when the preview is removed.