### PR TITLE
fix: Properly clean up asset tool state on exit

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2511,6 +2511,10 @@ function propagateCharacterUpdate(characterId) {
             if (footerAssetsTab) footerAssetsTab.style.display = 'none';
             const toolsTabButton = document.querySelector('.footer-tab-button[data-tab="footer-tools"]');
             if (toolsTabButton) toolsTabButton.click();
+
+            // Reset asset preview state
+            selectedAssetPath = null;
+            updateAssetPreview();
         });
     }
 


### PR DESCRIPTION
This commit fixes a bug where the asset preview and placement functionality would remain active after closing the Assets tool via the "Done" button.

The event listener for the "Done" button was only hiding the UI. It now also resets the asset preview state by setting `selectedAssetPath` to null and calling `updateAssetPreview()`. This ensures that the preview is cleared from the canvas and all associated event listeners are removed, returning the canvas to its normal state.