### PR TITLE
feat: Add asset selection and transformation tool

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -111,6 +111,7 @@
             <button id="btn-shadow-done">Done</button>
         </div>
         <div id="assets-tools-container" style="display: none; position: absolute; top: 10px; left: 10px; z-index: 4;">
+            <button id="btn-assets-select">Select</button>
             <button id="btn-assets-done">Done</button>
         </div>
         <canvas id="dm-canvas"></canvas>


### PR DESCRIPTION
This commit introduces a new "Select" tool to the Assets toolbar.

When activated, this tool allows the user to click on any placed asset on the map to select it. A transformation box with handles is drawn around the selected asset.

Users can:
- Drag the corner handles to uniformly scale the asset.
- Drag the rotation handle (a circle extending from the top edge) to rotate the asset around its center.

The new `scale` and `rotation` properties are saved and loaded with the campaign data, ensuring that transformed assets persist across sessions. The save/load functionality is backward-compatible with older saves that do not have these properties.