### PR TITLE
fix: Player view rendering for transformed assets

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -4767,6 +4767,16 @@ function propagateCharacterUpdate(characterId) {
                                             };
                                         }
                                     }
+                                    // For placed assets, find the asset data and embed its URL for the player view
+                                    if (overlay.type === 'placedAsset') {
+                                        const assetData = findAssetByPath(overlay.path);
+                                        if (assetData && assetData.url) {
+                                            return {
+                                                ...overlay,
+                                                dataUrl: assetData.url // Add the data URL for the player view
+                                            };
+                                        }
+                                    }
                                     return overlay;
                                 });
 

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -472,7 +472,35 @@ function drawOverlays_PlayerView(overlays) {
                     pCtx.beginPath(); // Reset path after clipping
                 }
             }
-        }
+        } else if (overlay.type === 'placedAsset' && overlay.position && overlay.dataUrl) {
+                let img = imageCache.get(overlay.dataUrl);
+                if (!img) {
+                    img = new Image();
+                    img.src = overlay.dataUrl;
+                    img.onload = () => {
+                        // Request a redraw from the main logic once the image is loaded
+                        drawMapAndOverlays();
+                    };
+                    imageCache.set(overlay.dataUrl, img);
+                }
+
+                if (img.complete) {
+                    const assetScale = overlay.scale || 1;
+                    const assetRotation = overlay.rotation || 0;
+
+                    // The context is already transformed by the map scale, so we just use asset properties
+                    const assetRenderWidth = overlay.width * assetScale;
+                    const assetRenderHeight = overlay.height * assetScale;
+
+                    pCtx.save();
+                    pCtx.translate(overlay.position.x, overlay.position.y);
+                    pCtx.rotate(assetRotation);
+
+                    pCtx.drawImage(img, -assetRenderWidth / 2, -assetRenderHeight / 2, assetRenderWidth, assetRenderHeight);
+
+                    pCtx.restore();
+                }
+            }
         });
     }
 


### PR DESCRIPTION
This commit fixes a bug where the player view would fail to display placed assets after the introduction of the asset transformation feature.

The root cause was that the player view's drawing logic was not updated to handle the new `scale` and `rotation` properties of assets. Additionally, the player view had no way to access the asset image data from the relative path stored in the asset object.

The fix includes two parts:
1.  In `dm_view.js`, the `sendMapToPlayerView` function is updated to embed the asset's base64 data URL directly into the overlay object sent to the player view.
2.  In `player_view.js`, the `drawOverlays_PlayerView` function is updated with the necessary logic to render `placedAsset` objects, using the provided data URL and applying the correct scale and rotation transformations.