### PR TITLE
Fix: Correct player view zoom to match DM view

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -558,7 +558,7 @@ window.addEventListener('message', (event) => {
                             const viewRect = data.viewRectangle;
                             const hScale = playerCanvas.width / viewRect.width;
                             const vScale = playerCanvas.height / viewRect.height;
-                            const scale = Math.min(hScale, vScale);
+                            const scale = playerCanvas.width / viewRect.width;
                             const renderedWidth = viewRect.width * scale;
                             const renderedHeight = viewRect.height * scale;
                             currentMapTransform.scale = scale;
@@ -585,9 +585,7 @@ window.addEventListener('message', (event) => {
             case 'mapTransformUpdate':
                 if (data.viewRectangle) {
                     const viewRect = data.viewRectangle;
-                    const hScale = playerCanvas.width / viewRect.width;
-                    const vScale = playerCanvas.height / viewRect.height;
-                    const scale = Math.min(hScale, vScale);
+                    const scale = playerCanvas.width / viewRect.width;
                     const renderedWidth = viewRect.width * scale;
                     const renderedHeight = viewRect.height * scale;
                     currentMapTransform.scale = scale;


### PR DESCRIPTION
The player view was previously calculating its own scale factor to fit the entirety of the DM's visible rectangle into its canvas. This caused the player view to appear more zoomed out than the DM's view, especially when the two windows had different aspect ratios.

This change modifies the scaling logic in `player_view.js`. The player view now calculates its scale based on the width of the received view rectangle, ensuring that its horizontal zoom level precisely matches the DM's view. This provides a more accurate and mirrored experience as intended.