### PR TITLE
feat: Implement asset stamp tool and preview pane

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3166,12 +3166,7 @@ function propagateCharacterUpdate(characterId) {
     }
 
     function updateAssetPreview(assetToPreview = null) {
-        // First, always clear the old canvas-based preview method
-        dmCanvas.removeEventListener('mousemove', handleAssetPreviewMouseMove);
-        dmCanvas.removeEventListener('mouseout', handleAssetPreviewMouseOut);
-        // dmCanvas.removeEventListener('click', handlePlaceAsset); // REMOVED: Placement is now handled by the stamp tool
-        handleAssetPreviewMouseOut(); // This clears any lingering canvas drawings
-        selectedAssetForPreview = null; // This is the old canvas-preview image object
+        selectedAssetForPreview = null;
 
         const assetData = assetToPreview || findAssetByPath(selectedAssetPath);
 

--- a/jules-scratch/verification/dummy_asset.svg
+++ b/jules-scratch/verification/dummy_asset.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" fill="blue" />
+</svg>

--- a/jules-scratch/verification/verify_asset_tools.py
+++ b/jules-scratch/verification/verify_asset_tools.py
@@ -1,0 +1,74 @@
+import os
+from playwright.sync_api import sync_playwright, expect
+
+def run_verification(playwright):
+    # Setup
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Get the absolute path to the HTML file
+    # This is necessary because `page.goto` needs a proper URL or an absolute file path.
+    # The current working directory is the root of the repository.
+    html_file_path = os.path.abspath('Projects/DnDemicube/dm_view.html')
+
+    try:
+        # 1. Navigate to the page
+        page.goto(f'file://{html_file_path}')
+
+        # 2. Open the asset tools
+        # Right-click on the canvas to open the map tools context menu
+        page.locator('#dm-canvas').click(button='right')
+        # Click the "Assets Tool" button
+        page.get_by_text('Assets Tool').click()
+
+        # 3. Upload the dummy asset
+        # The input is hidden, so we can't use a locator. We need to listen for the
+        # file chooser event that is triggered by clicking the upload button.
+        with page.expect_file_chooser() as fc_info:
+            page.locator('#upload-assets-folder-btn').click()
+
+        file_chooser = fc_info.value
+        # We need the absolute path for the asset as well.
+        asset_path = os.path.abspath('jules-scratch/verification/dummy_asset.svg')
+        file_chooser.set_files(asset_path)
+
+        # 4. Select the uploaded asset from the library
+        # The asset should now be visible in the asset explorer.
+        page.locator('.asset-item', has_text='dummy_asset.svg').click()
+
+        # 5. Verify the preview pane appears
+        asset_preview = page.locator('#asset-preview-container')
+        expect(asset_preview).to_be_visible()
+        expect(asset_preview.locator('#asset-preview-title')).to_have_text('dummy_asset.svg')
+
+        # 6. Activate the "Stamp" tool
+        page.locator('#btn-assets-stamp').click()
+
+        # 7. Click on the canvas to place the asset
+        page.locator('#dm-canvas').click(position={'x': 200, 'y': 200})
+
+        # 8. Activate the "Select" tool
+        page.locator('#btn-assets-select').click()
+
+        # 9. Click on the placed asset
+        # We click on the same coordinates where we placed it.
+        page.locator('#dm-canvas').click(position={'x': 200, 'y': 200})
+
+        # 10. Use the opacity slider to change the asset's opacity
+        opacity_slider = page.locator('#asset-preview-opacity')
+        # To set the slider value, we can use the `fill` method with the desired value.
+        opacity_slider.fill('0.5')
+
+        # Add a small delay to ensure the re-render with new opacity is complete
+        page.wait_for_timeout(500)
+
+        # 11. Take a screenshot
+        page.screenshot(path='jules-scratch/verification/verification.png')
+
+    finally:
+        # Teardown
+        browser.close()
+
+with sync_playwright() as playwright:
+    run_verification(playwright)


### PR DESCRIPTION
This commit introduces a new asset placement workflow and a dedicated preview pane with transformation controls.

Key changes:
- Adds a "Stamp" tool and a "Select" tool to the assets toolbar. Selecting an asset from the library now only updates the preview pane. The "Stamp" tool must be activated to place the asset on the map.
- The "Select" and "Stamp" tools are mutually exclusive toggles. When active, pan/zoom on the map is disabled.
- Adds an asset preview pane that shows the selected asset from the library or the map. It reflects the asset's scale, rotation, and opacity.
- Adds an opacity slider to the preview pane. Placed assets now render with their stored opacity.
- Selecting a placed asset with the "Select" tool updates the preview pane with its properties and allows for real-time transformation (move, scale, rotate).
- Refactors the asset-related JavaScript logic into more robust and maintainable functions.