### PR TITLE
fix: Preserve selected library asset when switching tools

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2867,8 +2867,6 @@ function propagateCharacterUpdate(characterId) {
 
             // If we are turning select mode ON
             if (!wasActive) {
-                // Deselect any footer asset to avoid confusion between stamping and selecting.
-                selectedAssetPath = null;
                 updateAssetPreview();
             } else { // If we are turning select mode OFF
                 // Deselect any placed asset


### PR DESCRIPTION
This commit fixes a bug where the 'Stamp' tool would forget which asset was selected after the user switched to the 'Select' tool and back.

The issue was caused by the 'Select' tool's event listener incorrectly clearing the `selectedAssetPath` variable. This change removes the line that nullifies the variable, ensuring the state is preserved correctly across tool switches.