### PR TITLE
Fix asset tool bugs and add hotfix for reset logic

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3146,6 +3146,7 @@ function propagateCharacterUpdate(characterId) {
     }
 
     function findAssetByPath(path) {
+        if (!path) return null;
         const parts = path.split('/');
         let currentLevel = assetsByPath;
         for (let i = 0; i < parts.length; i++) {


### PR DESCRIPTION
This commit addresses three bugs related to the Assets tool:
1. The Assets tool now correctly closes when entering "Active" mode or when another tool is selected from the map's context menu. This is handled by a centralized `resetAllInteractiveStates` function.
2. Selecting a placed asset on the map now correctly updates the asset preview pane and footer to reflect the selected asset's specific properties (scale, rotation, opacity). The "Stamp" and "Chain" tools will use this newly selected asset as the active one.
3. Assets drawn with the "Chain" tool now appear immediately after the operation is complete.

This commit also includes a hotfix to prevent a TypeError (`Cannot read properties of null (reading 'split')`) that occurred when the `resetAllInteractiveStates` function was called in certain scenarios. A null check has been added to the `findAssetByPath` function to make it more robust.