### PR TITLE
fix: Correct visual bug during marquee selection

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -4326,7 +4326,7 @@ function getTightBoundingBox(img) {
             if (isSelecting && selectionBox) {
                 selectionBox.endX = e.offsetX;
                 selectionBox.endY = e.offsetY;
-                displayMapOnCanvas(selectedMapFileName); // This will redraw overlays including the marquee
+                requestRedraw(); // Use the lighter redraw function
                 return;
             }
 


### PR DESCRIPTION
This commit fixes a visual bug where assets on the map would disappear while the user was dragging a marquee selection box.

The issue was caused by the `mousemove` event handler calling the heavy `displayMapOnCanvas()` function on every mouse movement. This function reloaded the entire map and its assets, causing a flicker.

The fix replaces this with a call to `requestRedraw()`, which is a much lighter, optimized function that uses `requestAnimationFrame` to smoothly draw the selection box over the existing canvas content without causing the assets to disappear.