### PR TITLE
fix: Synchronize asset preview with multi-selection

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -2465,11 +2465,11 @@ function getTightBoundingBox(img) {
             }
 
             const lastSelected = selectedPlacedAssets.length > 0 ? selectedPlacedAssets[selectedPlacedAssets.length - 1] : null;
-            updateAssetPreview(lastSelected);
             if (lastSelected) {
                 selectedAssetPath = lastSelected.path;
-                renderAssetExplorer();
             }
+            updateAssetPreview(lastSelected);
+            renderAssetExplorer();
             displayMapOnCanvas(selectedMapFileName);
         }
     });
@@ -3739,11 +3739,11 @@ function getTightBoundingBox(img) {
             }
             selectionBox = null;
             const lastSelected = selectedPlacedAssets.length > 0 ? selectedPlacedAssets[selectedPlacedAssets.length - 1] : null;
-            updateAssetPreview(lastSelected);
             if (lastSelected) {
                 selectedAssetPath = lastSelected.path;
-                renderAssetExplorer();
             }
+            updateAssetPreview(lastSelected);
+            renderAssetExplorer();
             displayMapOnCanvas(selectedMapFileName); // Redraw to remove marquee and show selections
         }
 


### PR DESCRIPTION
This commit fixes a UI synchronization bug where the asset preview pane and the footer asset explorer would not update to reflect the last-selected item in a multi-selection group.

The issue was a race condition where `updateAssetPreview()` was called before the global `selectedAssetPath` variable was updated.

The fix reorders the statements in the `mousedown` and `mouseup` event listeners to ensure `selectedAssetPath` is set with the latest selected asset's path *before* the UI preview is updated. This ensures the UI is always in sync with the underlying state that drives the Stamp and Chain tools.