### PR TITLE
Fix(assets): Restore chain tool's start/end point slider

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3207,6 +3207,8 @@ function getTightBoundingBox(img) {
         } else {
             mapContainer.style.cursor = 'grab';
         }
+
+        updateAssetPreview();
     }
 
     if (btnAssetsSelect) {


### PR DESCRIPTION
A regression caused the start/end point slider for the Chain Tool's asset preview to disappear.

The `setActiveAssetTool` function was missing a call to `updateAssetPreview`. This meant the preview pane was not being re-evaluated when the Chain tool was selected, so its specific controls (the slider) were not displayed.

The fix adds the `updateAssetPreview()` call to the end of the `setActiveAssetTool` function, ensuring the preview is always updated when the tool changes.