### PR TITLE
Fix(linking): Correct state handling for map icon linking

### DIFF
--- a/Projects/DnDemicube/character_sheet.html
+++ b/Projects/DnDemicube/character_sheet.html
@@ -22,6 +22,12 @@
                     <input type="checkbox" id="details-visibility-toggle" name="details_visibility_toggle" checked>
                     <label for="details-visibility-toggle" style="font-size: 0.8em;">Show Details to Players</label>
                 </div>
+                <div class="vision-controls" style="margin-top: 5px; text-align: center; font-size: 0.8em;">
+                    <input type="checkbox" id="vision-checkbox" name="vision" checked>
+                    <label for="vision-checkbox">Vision</label>
+                    <input type="number" id="vision-ft-input" name="vision_ft" style="width: 40px;" value="0">
+                    <label for="vision-ft-input">ft</label>
+                </div>
             </div>
                 <div class="char-details">
                     <div>

--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -192,6 +192,16 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    const visionCheckbox = document.getElementById('vision-checkbox');
+    if (visionCheckbox) {
+        visionCheckbox.addEventListener('change', function() {
+            window.parent.postMessage({
+                type: 'characterVisionChange',
+                vision: this.checked
+            }, '*');
+        });
+    }
+
     window.addEventListener('message', function(event) {
         if (event.data.type === 'loadCharacterSheet') {
             clearSheetFields();
@@ -218,6 +228,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
             if (detailsVisibilityToggle) {
                 detailsVisibilityToggle.checked = typeof data.isDetailsVisible === 'boolean' ? data.isDetailsVisible : true;
+            }
+            if (visionCheckbox) {
+                visionCheckbox.checked = typeof data.vision === 'boolean' ? data.vision : true;
+            }
+        } else if (event.data.type === 'characterVisionChange_from_dm') {
+            if (visionCheckbox) {
+                visionCheckbox.checked = event.data.vision;
             }
         } else if (event.data.type === 'requestSheetData') {
             const sheetData = {};

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -504,6 +504,16 @@
         <div class="token-stat-block-content">
             <h4 id="token-stat-block-char-name"></h4>
             <p id="token-stat-block-player-name"></p>
+            <div class="token-stat-block-toggles" style="display: flex; justify-content: space-around; margin-bottom: 10px;">
+                <div>
+                    <input type="checkbox" id="token-stat-block-details-toggle">
+                    <label for="token-stat-block-details-toggle">Show Details</label>
+                </div>
+                <div>
+                    <input type="checkbox" id="token-stat-block-vision-toggle">
+                    <label for="token-stat-block-vision-toggle">Vision</label>
+                </div>
+            </div>
             <div class="stat-block-health">
                 <label for="token-stat-block-hp">HP:</label>
                 <input type="number" id="token-stat-block-hp" class="token-stat-block-hp-input">

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -237,7 +237,7 @@ function recalculateLightMap_Player() {
 
     const dmLightSources = currentOverlays.filter(o => o.type === 'lightSource');
     const tokenLightSources = initiativeTokens
-        .filter(token => token.isDetailsVisible !== false)
+        .filter(token => token.vision !== false)
         .map(token => ({
             type: 'lightSource',
             position: { x: token.x, y: token.y },


### PR DESCRIPTION
The `switchTab` function was incorrectly resetting all interactive states when switching to the notes or characters tab to link an item to a map icon. This caused the application to forget which icon was being linked.

This commit modifies `switchTab` to accept a `preserveState` parameter. When linking, the call to `switchTab` now passes `true` for this parameter, preventing the state from being cleared and allowing the linking operation to complete successfully.

Feat(vision): Add vision controls and syncing

This commit introduces two new features related to character vision and UI syncing:

1.  **Character Vision Control:**
    -   A 'Vision' checkbox and 'ft' input have been added to the character sheet.
    -   The 'Vision' checkbox now controls whether a character's token contributes to revealing the map in the player view. This decouples token vision from the 'Show Details to Players' setting.
    -   The underlying character data model has been updated to include and persist the `vision` state.
    -   The `player_view.js` logic has been updated to use this new `vision` property for lighting calculations.

2.  **DM Control Syncing:**
    -   'Show Details' and 'Vision' checkboxes have been added to the token's right-click stat block in the DM view.
    -   These checkboxes are now two-way synced with the corresponding controls on the main character sheet. Changes made in one location are reflected in the other, providing DMs with a more convenient way to manage token visibility during a session.