### PR TITLE
feat: Implement cumulative, shadow-based Fog of War system

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -227,6 +227,12 @@
         </ul>
     </div>
 
+    <div id="view-mode-map-context-menu" class="context-menu" style="display: none; position: absolute;">
+        <ul>
+            <li data-action="reset-fog-of-war">Reset Fog of War</li>
+        </ul>
+    </div>
+
     <div id="map-tools-context-menu" class="context-menu" style="display: none; position: absolute;">
         <ul>
             <li data-action="link-child-map">Link to Child Map</li>

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -217,6 +217,7 @@
     <div id="player-map-container">
         <canvas id="player-canvas"></canvas>
         <canvas id="player-shadow-canvas" style="position: absolute; pointer-events: none;"></canvas>
+        <canvas id="fog-canvas" style="position: absolute; pointer-events: none;"></canvas>
         <div id="dice-roller-icon" class="absolute bottom-5 right-5 w-12 h-12 cursor-pointer z-10">
             <img src="assets/d20icon.png" alt="d20 icon" class="w-full h-full">
         </div>


### PR DESCRIPTION
This commit introduces a comprehensive Fog of War feature for the player view.

Key features:
- A cumulative, per-map Fog of War layer is now generated and saved.
- Fog is revealed based on the precise line-of-sight vision of player tokens, taking into account walls, doors, and other obstacles.
- Explored areas that are no longer in sight are displayed to players as a greyed-out 'remembered' map, rather than being completely obscured by shadows.
- A 'Reset Fog of War' option has been added to a context menu for the DM in view mode, allowing for a complete reset of the fog on the current map.
- The fog of war state (`fogOfWarDataUrl`) is integrated into the campaign save/load functionality, ensuring persistence.
- The system is backward-compatible with old saves, which will load with a fresh, fully-fogged map.