### PR TITLE
fix: Correct player view canvas positioning

### DIFF
--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -28,7 +28,15 @@
             color: #e0e0e0;
         }
         #player-map-container { width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; position: relative; }
-        #player-canvas { max-width: 100%; max-height: 100%; border: 1px solid #3f4c5a; background-color: #2a3138;}
+        #player-map-container > canvas {
+            position: absolute;
+            max-width: 100%;
+            max-height: 100%;
+            border: 1px solid #3f4c5a;
+        }
+        #player-canvas {
+            background-color: #2a3138; /* Keep background on base canvas only */
+        }
         .note-preview-overlay {
             position: fixed;
             top: 0;
@@ -216,8 +224,8 @@
     </div>
     <div id="player-map-container">
         <canvas id="player-canvas"></canvas>
-        <canvas id="player-shadow-canvas" style="position: absolute; pointer-events: none;"></canvas>
-        <canvas id="fog-canvas" style="position: absolute; pointer-events: none;"></canvas>
+        <canvas id="player-shadow-canvas" style="pointer-events: none;"></canvas>
+        <canvas id="fog-canvas" style="pointer-events: none;"></canvas>
         <div id="dice-roller-icon" class="absolute bottom-5 right-5 w-12 h-12 cursor-pointer z-10">
             <img src="assets/d20icon.png" alt="d20 icon" class="w-full h-full">
         </div>

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -155,21 +155,18 @@ function resizePlayerCanvas() {
 
     const top = (containerHeight - newHeight) / 2;
     const left = (containerWidth - newWidth) / 2;
-    playerCanvas.style.position = 'absolute';
     playerCanvas.style.top = `${top}px`;
     playerCanvas.style.left = `${left}px`;
 
     if (shadowCanvas) {
         shadowCanvas.width = newWidth;
         shadowCanvas.height = newHeight;
-        shadowCanvas.style.position = 'absolute';
         shadowCanvas.style.top = `${top}px`;
         shadowCanvas.style.left = `${left}px`;
     }
     if (fogCanvas) {
         fogCanvas.width = newWidth;
         fogCanvas.height = newHeight;
-        fogCanvas.style.position = 'absolute';
         fogCanvas.style.top = `${top}px`;
         fogCanvas.style.left = `${left}px`;
     }


### PR DESCRIPTION
This commit fixes a visual bug where the fog of war canvas was stretched and misaligned on the player's view.

The fix involves:
- Consolidating canvas positioning into a single CSS rule to ensure all map layers (`player-canvas`, `shadow-canvas`, `fog-canvas`) are sized and positioned identically.
- Removing redundant inline styles from the HTML.
- Removing redundant JavaScript style assignments.