### PR TITLE
fix: Ensure fog of war canvas transforms match main map

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -593,12 +593,16 @@ window.addEventListener('message', (event) => {
 
                         // Now, prepare the fog canvas
                         if (fCtx) {
-                            fCtx.clearRect(0, 0, fogCanvas.width, fogCanvas.height); // Clear old fog
-                            // Draw the map again on the fog canvas
-                            fCtx.drawImage(img, 0, 0, fogCanvas.width, fogCanvas.height);
-                            // Overlay it with grey
+                            fCtx.clearRect(0, 0, fogCanvas.width, fogCanvas.height);
+                            // Draw the greyed-out map version, applying the same transform as the main canvas
+                            fCtx.save();
+                            fCtx.translate(currentMapTransform.originX, currentMapTransform.originY);
+                            fCtx.scale(currentMapTransform.scale, currentMapTransform.scale);
+                            fCtx.drawImage(img, 0, 0, img.width, img.height);
                             fCtx.fillStyle = 'rgba(0, 0, 0, 0.6)';
-                            fCtx.fillRect(0, 0, fogCanvas.width, fogCanvas.height);
+                            fCtx.globalCompositeOperation = 'source-atop';
+                            fCtx.fillRect(0, 0, img.width, img.height);
+                            fCtx.restore();
                         }
 
                         isLightMapDirty = true;
@@ -782,19 +786,24 @@ window.addEventListener('message', (event) => {
                 if (fCtx && data.fogOfWarDataUrl) {
                     const fogImg = new Image();
                     fogImg.onload = () => {
-                        // The greyed-out map is already on the fog canvas.
-                        // We use 'destination-in' to keep the greyed-out map only where the fog mask is opaque (black).
-                        // This erases the greyed-out map where the fog mask is transparent, revealing the full-color map underneath.
+                        // The greyed-out map is on the fog canvas, correctly transformed.
+                        // The fogImg is a mask that is the same size as the original map image.
+                        // We need to apply it with the same transform to align them.
                         fCtx.save();
+                        // This operation keeps the destination (grey map) only where the source (fog mask) is.
+                        // Since the fog mask is black (opaque) where there's fog, this correctly preserves the greyed-out areas.
                         fCtx.globalCompositeOperation = 'destination-in';
-                        fCtx.drawImage(fogImg, 0, 0, fogCanvas.width, fogCanvas.height);
+                        fCtx.translate(currentMapTransform.originX, currentMapTransform.originY);
+                        fCtx.scale(currentMapTransform.scale, currentMapTransform.scale);
+                        fCtx.drawImage(fogImg, 0, 0, currentMapImage.width, currentMapImage.height);
                         fCtx.restore();
                     };
                     fogImg.src = data.fogOfWarDataUrl;
                 } else if (fCtx) {
-                    // If the DM sends a null/empty FOW (e.g., for a new map), clear the fog canvas.
-                    // This results in the full color map being visible.
-                    fCtx.clearRect(0, 0, fogCanvas.width, fogCanvas.height);
+                    // This case might be hit if a map is reset. A full grey overlay is desired.
+                    // The loadMap logic already handles creating the initial grey overlay, so we just need to not erase it.
+                    // A better approach might be to have the DM send a solid black FOW data URL upon reset.
+                    // The current DM-side reset logic does this, so this else block may not be necessary.
                 }
                 break;
             default:


### PR DESCRIPTION
This commit fixes a bug where the fog of war layer on the player view was stretched and misaligned.

The cause was that the content drawn within the `fog-canvas` was not using the same scaling and translation transformations as the main `player-canvas`.

The fix ensures that both when the initial greyed-out map is prepared and when the fog mask is applied, the drawing operations use the exact same transformation matrix as the main map, guaranteeing perfect alignment.