### PR TITLE
Fix(player-view): Correct fog of war rendering

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -791,6 +791,19 @@ window.addEventListener('message', (event) => {
                         fCtx.scale(currentMapTransform.scale, currentMapTransform.scale);
                         fCtx.drawImage(fogImg, 0, 0, currentMapImage.width, currentMapImage.height);
                         fCtx.restore();
+
+                        // Finally, clear the fog from areas that are currently visible.
+                        // The lightMapCanvas is black in shadowed areas and transparent in lit areas.
+                        // 'destination-in' will keep the fog only where the new shape (lightMapCanvas) is drawn.
+                        if (lightMapCanvas) {
+                            fCtx.save();
+                            fCtx.globalCompositeOperation = 'destination-in';
+                            fCtx.translate(currentMapTransform.originX, currentMapTransform.originY);
+                            fCtx.scale(currentMapTransform.scale, currentMapTransform.scale);
+                            // Draw the light map, which represents shadows, to effectively "keep" the fog only in shadowed areas.
+                            fCtx.drawImage(lightMapCanvas, 0, 0, currentMapDisplayData.imgWidth, currentMapDisplayData.imgHeight);
+                            fCtx.restore();
+                        }
                     };
                     fogImg.src = data.fogOfWarDataUrl;
                 }


### PR DESCRIPTION
The historical fog of war layer was being drawn over areas currently visible to player tokens. This change corrects the rendering logic.

In the `fogOfWarUpdate` handler, after drawing the historical fog layer, the `lightMapCanvas` is now used as a mask with the `destination-in` composite operation. This ensures that the historical fog is cleared from any areas that are actively lit by token vision or other light sources, leaving the fog only in previously explored but currently shadowed areas.

This change is purely a client-side rendering fix and does not affect the save/load data format.