### PR TITLE
feat: Add quest log overlay to player view

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -231,6 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let isPanning = false;
     let panStartX = 0;
     let panStartY = 0;
+    let isQuestLogVisible = false;
 
     // Core state variables
     let selectedMapFileName = null;
@@ -11588,8 +11589,6 @@ function getDragAfterElement(container, y) {
 
     // Initial call to populate footer
     renderActiveQuestsInFooter();
-
-    let isQuestLogVisible = false;
 
     function sendQuestLogData() {
         if (!playerWindow || playerWindow.closed) return;


### PR DESCRIPTION
This commit introduces a new 'Quest Log' button in the DM's quest footer. When clicked, this button toggles a quest log overlay on the player's view.

The overlay displays the following information for the currently active quest:
- Quest Title
- A list of completed story step titles
- The next uncompleted story step

The overlay is positioned in the top-right corner of the player's screen and has a semi-transparent background.

The implementation ensures that the quest log content automatically updates whenever the DM selects a different active quest or when a story step's completion status changes.

Fixes an initialization error with the `isQuestLogVisible` flag by moving its declaration to the top of the script with other state variables.