### PR TITLE
Fix: Correct player view layout issue

### DIFF
--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -225,7 +225,7 @@
         <p id="author-text" class="text-xl font-bold"></p>
     </div>
     </div>
-    <div id="player-map-container">
+    <div id="player-map-container" class="w-full h-screen">
         <canvas id="player-canvas"></canvas>
         <canvas id="player-shadow-canvas" style="pointer-events: none;"></canvas>
         <canvas id="fog-canvas" style="pointer-events: none;"></canvas>


### PR DESCRIPTION
The player view was not displaying correctly, with all elements shrunk to the top of the screen. This was caused by the main container, `player-map-container`, having a height of 0 because its parent `<body>` did not have a specified height.

This change adds the `w-full` and `h-screen` Tailwind CSS classes to the `player-map-container` div in `player_view.html`. This ensures the container spans the full width and height of the viewport, resolving the layout issue.