### PR TITLE
Fix quest overlay in player view to correctly display next and comple…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -11599,16 +11599,24 @@ function getDragAfterElement(container, y) {
             return;
         }
 
-        const completedSteps = quest.storySteps.filter(step => step.completed).map(step => step.title);
-        const nextStep = quest.storySteps.find(step => !step.completed);
+        const getStepDescription = (step) => {
+            if (!step) return '';
+            if (typeof step === 'string') return step; // Backward compatibility
+            // The DM sees the `text` as the main description, so the player should too.
+            return step.text || step.title || '';
+        };
+
+        const completedSteps = quest.storySteps.filter(step => step && step.completed).map(getStepDescription);
+        const nextStepObject = quest.storySteps.find(step => step && !step.completed);
+        const nextStep = nextStepObject ? getStepDescription(nextStepObject) : "All steps completed!";
 
         playerWindow.postMessage({
             type: 'updateQuestOverlay',
             visible: isQuestLogVisible,
             quest: {
                 title: quest.name,
-                completedSteps: completedSteps,
-                nextStep: nextStep ? nextStep.title : "All steps completed!"
+                completedSteps: completedSteps, // This is now an array of strings
+                nextStep: nextStep // This is now a string
             }
         }, '*');
     }


### PR DESCRIPTION
…ted steps.

The `sendQuestLogData` function in `dm_view.js` was updated to send the correct description for quest steps to the player view. Previously, it was only sending the step's title, which could be blank or incorrect, causing the player's quest overlay to display improperly.

The function now uses a helper to get the step description, prioritizing the `text` field over the `title` field and ensuring backward compatibility with older save formats. This aligns the data sent to the player view with what the DM sees in their quest footer.