### PR TITLE
feat: Display story step title in player quest log

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -11606,9 +11606,15 @@ function getDragAfterElement(container, y) {
             return step.text || step.title || '';
         };
 
-        const completedSteps = quest.storySteps.filter(step => step && step.completed).map(getStepDescription);
+        const getPlayerStepDescription = (step) => {
+            if (!step) return '';
+            if (typeof step === 'string') return step; // Backward compatibility
+            return step.title || step.text || '';
+        };
+
+        const completedSteps = quest.storySteps.filter(step => step && step.completed).map(getPlayerStepDescription);
         const nextStepObject = quest.storySteps.find(step => step && !step.completed);
-        const nextStep = nextStepObject ? getStepDescription(nextStepObject) : "All steps completed!";
+        const nextStep = nextStepObject ? getPlayerStepDescription(nextStepObject) : "All steps completed!";
 
         playerWindow.postMessage({
             type: 'updateQuestOverlay',


### PR DESCRIPTION
Modified the `sendQuestLogData` function in `dm_view.js` to ensure that only the story step's title is sent to the player's quest log overlay.

The previous implementation sent the full, detailed text of the step. This change introduces a local helper function, `getPlayerStepDescription`, which prioritizes the `step.title` field over the `step.text` field.

This change ensures the player sees a concise quest objective, while the DM's view and the action log (which already used the title) remain unchanged, fulfilling all requirements of the original request.