### PR TITLE
feat: Implement auto-shadow feature for assets

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -495,6 +495,35 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* Sizing for smaller toggle switch */
+.switch.is-small {
+  width: 40px;
+  height: 22px;
+}
+
+.switch.is-small .slider:before {
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+}
+
+.switch.is-small input:checked + .slider:before {
+  transform: translateX(18px);
+}
+
+/* Styling for the labels next to the toggle */
+.toggle-label {
+    font-size: 12px;
+    color: #a0b4c9; /* Muted color for non-active */
+    transition: color 0.3s ease;
+}
+
+.toggle-label.active {
+    color: #e0e0e0; /* Brighter color for active */
+    font-weight: bold;
+}
+
 /* Asset Preview Pane */
 #asset-preview-container {
     padding: 10px;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -132,6 +132,18 @@
                     <input type="range" id="asset-preview-opacity" min="0" max="1" step="0.05" value="1">
                     <span id="asset-preview-opacity-value">1.0</span>
                 </div>
+                <div class="asset-preview-slider-container" id="auto-shadow-container">
+                    <label for="auto-shadow-checkbox" style="white-space: nowrap;">Auto-Shadow</label>
+                    <input type="checkbox" id="auto-shadow-checkbox" style="margin-left: 5px;">
+                    <div class="auto-shadow-toggle" style="margin-left: 15px; display: flex; align-items: center;">
+                        <span id="auto-shadow-wall-label" class="toggle-label active">Wall</span>
+                        <label class="switch is-small">
+                            <input type="checkbox" id="auto-shadow-mode-toggle">
+                            <span class="slider round"></span>
+                        </label>
+                        <span id="auto-shadow-object-label" class="toggle-label">Object</span>
+                    </div>
+                </div>
                 <div id="asset-chain-points-slider-container" class="asset-preview-slider-container" style="display: none;">
                     <label for="asset-chain-points">Chain Points</label>
                     <input type="range" id="asset-chain-points" min="0" max="100" step="1" value="0">


### PR DESCRIPTION
This commit introduces a new 'auto-shadow' feature to the asset tools in the DM view.

The feature includes:
- An 'auto-shadow' checkbox in the asset preview pane to enable or disable the effect.
- A 'Wall/Object' toggle to switch between shadow styles.

When enabled, the feature automatically applies a shadow to newly placed assets or currently selected assets.
- 'Wall' mode creates a line shadow between two adjustable points on the asset.
- 'Object' mode creates a polygon shadow that tightly wraps the asset's visible pixels using a convex hull algorithm.

The shadow is linked to the parent asset and is properly managed throughout its lifecycle (creation, deletion, and updates). This change also ensures that save and load functionality remains compatible with previous versions.