### PR TITLE
feat: Implement auto-shadow feature for assets

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3376,10 +3376,12 @@ function getTightBoundingBox(img) {
                 assetPreviewImage.style.opacity = opacity;
             }
 
-            // If an asset is selected on the map, update its opacity value directly
-            if (activeAssetTool === 'select' && selectedPlacedAsset) {
-                selectedPlacedAsset.opacity = opacity;
-                // Redraw the canvas to show the change on the placed asset immediately
+            // If assets are selected on the map, update their opacity value directly
+            if (activeAssetTool === 'select' && selectedPlacedAssets.length > 0) {
+                selectedPlacedAssets.forEach(asset => {
+                    asset.opacity = opacity;
+                });
+                // Redraw the canvas to show the change on the placed assets immediately
                 if (selectedMapFileName) {
                     displayMapOnCanvas(selectedMapFileName);
                 }


### PR DESCRIPTION
This commit introduces a new 'auto-shadow' feature to the asset tools in the DM view.

The feature includes:
- An 'auto-shadow' checkbox in the asset preview pane to enable or disable the effect.
- A 'Wall/Object' toggle to switch between shadow styles.

When enabled, the feature automatically applies a shadow to newly placed assets or currently selected assets.
- 'Wall' mode creates a line shadow between two adjustable points on the asset.
- 'Object' mode creates a polygon shadow that tightly wraps the asset's visible pixels using a convex hull algorithm.

The shadow is linked to the parent asset and is properly managed throughout its lifecycle (creation, deletion, and updates). This change also ensures that save and load functionality remains compatible with previous versions.

Fixes a bug where the opacity slider would cause a reference error due to using the old `selectedPlacedAsset` variable instead of the new `selectedPlacedAssets` array.