### PR TITLE
feat: Auto-populate custom rolls for attribute checks

### DIFF
--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -258,6 +258,30 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    if (addRollTagsSelect) {
+        addRollTagsSelect.addEventListener('change', () => {
+            const selectedTag = addRollTagsSelect.value;
+            const attributeTags = ['Strength', 'Dexterity', 'Constitution', 'Intelligence', 'Wisdom', 'Charisma'];
+
+            if (attributeTags.includes(selectedTag)) {
+                const attribute = selectedTag.toLowerCase();
+                const modifier = modifiers[attribute].textContent;
+
+                addRollNameInput.value = `${selectedTag} Check`;
+
+                // Reset dice counts
+                for (const die in sheetDiceCounts) {
+                    sheetDiceCounts[die] = 0;
+                }
+                // Set to 1d20
+                sheetDiceCounts['d20'] = 1;
+                updateCompactDiceDisplay();
+
+                addRollModifierInput.value = parseInt(modifier.replace('+', ''), 10) || 0;
+            }
+        });
+    }
+
     if (diceButtonsContainer) {
         diceButtonsContainer.addEventListener('click', (event) => {
             const button = event.target.closest('.dice-button-compact');


### PR DESCRIPTION
This commit introduces a new behavior to the custom roll form on the character sheet.

When a user selects an attribute tag (e.g., Strength, Dexterity) from the dropdown, the form now automatically populates with the standard values for an attribute check:
- The roll name is set to `{{Attribute}} Check`.
- The dice are set to a single d20.
- The modifier is set to the character's corresponding attribute modifier.

This streamlines the process for adding common attribute checks and ensures they are created correctly, while still allowing the user to further customize the roll before saving.