### PR TITLE
Feat: Auto-populate custom roll for attribute checks

### DIFF
--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -258,30 +258,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    if (addRollTagsSelect) {
-        addRollTagsSelect.addEventListener('change', () => {
-            const selectedTag = addRollTagsSelect.value;
-            const attributeTags = ['Strength', 'Dexterity', 'Constitution', 'Intelligence', 'Wisdom', 'Charisma'];
-
-            if (attributeTags.includes(selectedTag)) {
-                const attribute = selectedTag.toLowerCase();
-                const modifier = modifiers[attribute].textContent;
-
-                addRollNameInput.value = `${selectedTag} Check`;
-
-                // Reset dice counts
-                for (const die in sheetDiceCounts) {
-                    sheetDiceCounts[die] = 0;
-                }
-                // Set to 1d20
-                sheetDiceCounts['d20'] = 1;
-                updateCompactDiceDisplay();
-
-                addRollModifierInput.value = parseInt(modifier.replace('+', ''), 10) || 0;
-            }
-        });
-    }
-
     if (diceButtonsContainer) {
         diceButtonsContainer.addEventListener('click', (event) => {
             const button = event.target.closest('.dice-button-compact');
@@ -349,6 +325,31 @@ document.addEventListener('DOMContentLoaded', function() {
             } else if (action === 'roll') {
                 const savedRoll = characterSavedRolls[index];
                 window.parent.postMessage({ type: 'characterSheetRoll', rollData: savedRoll }, '*');
+            }
+        });
+    }
+
+    if (addRollTagsSelect) {
+        addRollTagsSelect.addEventListener('change', () => {
+            const selectedTag = addRollTagsSelect.value;
+            const attributeMatch = selectedTag.match(/^(Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma)$/);
+
+            if (attributeMatch) {
+                const attribute = attributeMatch[0].toLowerCase();
+                const statName = attribute.charAt(0).toUpperCase() + attribute.slice(1);
+
+                addRollNameInput.value = `${statName} Check`;
+
+                // Reset dice and add a d20
+                for (const die in sheetDiceCounts) {
+                    sheetDiceCounts[die] = 0;
+                }
+                sheetDiceCounts['d20'] = 1;
+                updateCompactDiceDisplay();
+
+                // Set modifier
+                const modifierValue = modifiers[attribute].textContent;
+                addRollModifierInput.value = parseInt(modifierValue, 10) || 0;
             }
         });
     }

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6132,6 +6132,35 @@ function getTightBoundingBox(img) {
         });
     }
 
+    if (tokenStatBlockAddRollTags) {
+        tokenStatBlockAddRollTags.addEventListener('change', () => {
+            if (!selectedTokenForStatBlock) return;
+            const character = activeInitiative.find(c => c.uniqueId === selectedTokenForStatBlock.uniqueId);
+            if (!character || !character.sheetData) return;
+
+            const selectedTag = tokenStatBlockAddRollTags.value;
+            const attributeMatch = selectedTag.match(/^(Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma)$/);
+
+            if (attributeMatch) {
+                const attribute = attributeMatch[0].toLowerCase();
+                const statName = attribute.charAt(0).toUpperCase() + attribute.slice(1);
+
+                tokenStatBlockAddRollName.value = `${statName} Check`;
+
+                // Reset dice and add a d20
+                for (const die in tokenStatBlockDiceCounts) {
+                    tokenStatBlockDiceCounts[die] = 0;
+                }
+                tokenStatBlockDiceCounts['d20'] = 1;
+                updateCompactDiceDisplay();
+
+                // Set modifier from character sheet data
+                const modifierValue = character.sheetData[`${attribute}_modifier`] || '+0';
+                tokenStatBlockAddRollModifier.value = parseInt(modifierValue.replace('+', ''), 10) || 0;
+            }
+        });
+    }
+
     if (tokenStatBlockRollsList) {
         tokenStatBlockRollsList.addEventListener('click', (event) => {
             const button = event.target;


### PR DESCRIPTION
This change modifies the custom roll feature for both character sheets and character tokens.

When a user selects an attribute tag (e.g., "Strength") in the custom roll interface, the form is now automatically populated with the standard parameters for an attribute check:
- A `d20` is selected as the die.
- The roll name is set to `{{Attribute}} Check`.
- The modifier input is populated with the corresponding attribute modifier from the character's data.

This ensures that attribute-based custom rolls use the correct, character-specific modifier, improving the workflow for contested checks and saving throws initiated from the custom roll menu. The change has been implemented for both the character sheet view and the token stat block view.