### PR TITLE
Feat: Comment out Roll card from automation

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -10733,7 +10733,7 @@ function displayCardDetails(cardElement) {
             // 5. Switch to the DM Controls tab to see the map
             switchTab('tab-dm-controls');
         });
-    } else if (cardElement.dataset.cardType === 'roll') {
+    } /* else if (cardElement.dataset.cardType === 'roll') {
     detailsSidebar.style.overflowY = 'auto';
     detailsSidebar.style.display = 'flex';
     detailsSidebar.style.flexDirection = 'column';
@@ -10966,7 +10966,7 @@ function displayCardDetails(cardElement) {
     renderSavedRollsList();
     renderCharacterSelectList();
     updateRollCardDiceDisplay();
-}
+}*/
 
 
     // --- Delete Button (for all cards) ---
@@ -11003,7 +11003,7 @@ function getDragAfterElement(container, y) {
         const toggleSwitch = document.getElementById('automation-mode-toggle-switch');
 
         const cardButtons = [
-            'Story Beat', 'Note', 'Character', 'Map', 'Wander', 'Initiative', 'Roll'
+            'Story Beat', 'Note', 'Character', 'Map', 'Wander', 'Initiative',// 'Roll'
         ];
 
         moduleCardsContainer.innerHTML = '';


### PR DESCRIPTION
Comments out the 'Roll' card functionality from the 'Story Beats > Automation' tab.

This change addresses the user's request to temporarily disable the feature. The 'Roll' button is removed from the sidebar, and the logic for displaying roll card details is also commented out. This allows the feature to be easily re-enabled in the future by uncommenting the relevant code blocks in `dm_view.js`.