### PR TITLE
feat: Add automation branch management

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -167,6 +167,16 @@
             <div id="module-cards-container">
                 <!-- Module cards will be dynamically added here -->
             </div>
+            <div id="automation-management-section" class="sidebar-section">
+                <h3>Management</h3>
+                <div style="display: flex; gap: 5px; margin-bottom: 10px;">
+                    <input type="text" id="automation-branch-name-input" placeholder="Branch Name" style="flex-grow: 1;">
+                    <button id="save-automation-branch-button">Save</button>
+                </div>
+                <ul id="automation-branches-list" style="list-style-type: none; padding: 0; max-height: 200px; overflow-y: auto;">
+                    <!-- Saved automation branches will be listed here -->
+                </ul>
+            </div>
         </div>
         <div id="automation-canvas-container">
             <div id="automation-canvas"></div>


### PR DESCRIPTION
This commit introduces a new "Management" section in the automation sidebar of the Story Beats tab. This feature allows users to save, load, and delete named "automation branches," which are saved layouts of automation cards.

Key changes:
- Added a "Management" section to `dm_view.html` with UI elements for saving and listing automation branches.
- Implemented save/load/delete logic for automation branches in `dm_view.js`.
- Refactored the data structure for saved automation cards to be more robust, storing structured data instead of raw `innerHTML`.
- Updated the main campaign save/load functionality to include automation branches, ensuring persistence and backward compatibility.