### PR TITLE
feat: Add automation to Story Beats tab

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -495,6 +495,16 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+#automation-controls {
+    text-align: center;
+}
+
+#automation-active-controls {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+}
+
 /* Sizing for smaller toggle switch */
 .switch.is-small {
   width: 40px;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -169,6 +169,14 @@
             </div>
             <div id="automation-management-section" class="sidebar-section">
                 <h3>Management</h3>
+                <div id="automation-controls" style="margin-bottom: 10px;">
+                    <button id="begin-automation-button">Begin</button>
+                    <div id="automation-active-controls" style="display: none; justify-content: space-between;">
+                        <button id="previous-automation-button">Previous</button>
+                        <button id="stop-automation-button">Stop</button>
+                        <button id="next-automation-button">Next</button>
+                    </div>
+                </div>
                 <div style="display: flex; gap: 5px; margin-bottom: 10px;">
                     <input type="text" id="automation-branch-name-input" placeholder="Branch Name" style="flex-grow: 1;">
                     <button id="save-automation-branch-button">Save</button>


### PR DESCRIPTION
This commit introduces a new automation feature to the "Story Beats" tab, allowing the DM to progress through the story beats automatically.

The following changes have been made:

-   Added "Begin", "Stop", "Previous", and "Next" buttons to the "Story Beats" tab in `dm_view.html`.
-   Implemented the logic for the automation buttons in `dm_view.js`.
-   The "Begin" button starts the automation and is replaced by the "Stop", "Previous", and "Next" buttons.
-   The "Next" button advances the automation to the next story beat card, activating it.
-   The "Previous" button moves the automation back to the previous story beat card.
-   The "Stop" button stops the automation.
-   The `activateCard` function has been created to handle the activation of different types of cards (Note, Character, Map, Initiative, Story Beat, etc.).
-   The save/load functionality has been updated to persist the state of the automation.
-   Added styles for the new buttons in `dm_view.css`.