### PR TITLE
feat: Add synchronized Automation tab to footer

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -1137,13 +1137,18 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     visibility: visible;
 }
 
-#footer-quests {
+#footer-quests,
+#footer-automation {
     width: 100%;
     justify-content: space-between;
     gap: 10px;
 }
 
-#footer-quests-left, #footer-quests-right, #footer-quests-center {
+#footer-quests-left,
+#footer-quests-right,
+#footer-quests-center,
+#footer-automation-left,
+#footer-automation-main {
     overflow-y: auto;
     padding: 10px;
     background-color: #15191e;

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -602,6 +602,7 @@
         <div class="footer-tabs">
             <button class="footer-tab-button active" data-tab="footer-tools">Tools</button>
             <button class="footer-tab-button" data-tab="footer-quests">Quests</button>
+            <button class="footer-tab-button" data-tab="footer-automation">Automation</button>
             <button class="footer-tab-button" data-tab="footer-assets" style="display: none;">Assets</button>
         </div>
         <div class="footer-content-container">
@@ -653,6 +654,14 @@
                     <div id="footer-active-quest-details">
                         <!-- Story steps content will go here -->
                     </div>
+                </div>
+            </div>
+            <div id="footer-automation" class="footer-tab-content">
+                <div id="footer-automation-left" style="flex: 1; padding: 10px; overflow-y: auto;">
+                    <!-- Automation controls and branch list will go here -->
+                </div>
+                <div id="footer-automation-main" style="flex: 3; padding: 10px; border-left: 1px solid #4a5f7a; overflow-y: auto;">
+                    <!-- Automation cards will go here -->
                 </div>
             </div>
             <div id="footer-assets" class="footer-tab-content">


### PR DESCRIPTION
This commit introduces a new "Automation" tab in the footer of the DM controls view.

The new tab mirrors the layout and functionality of the main automation controls found in the "Story Beats" section.

Key changes:
- Added HTML structure and CSS for the new "Automation" tab and its content in `dm_view.html` and `dm_view.css`.
- Implemented JavaScript in `dm_view.js` to:
  - Dynamically render the controls in the new footer tab.
  - Proxy click events from the footer controls to the original controls in the main view, reusing existing logic.
  - Use a `MutationObserver` to watch for changes in the main automation section (e.g., branch selection, play/stop state) and synchronize the footer tab's UI to match.

This provides the user with quick access to automation controls from the main map view without needing to switch to the "Story Beats" tab.