### PR TITLE
feat: Add synchronized Automation tab to footer

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -12946,7 +12946,6 @@ function getDragAfterElement(container, y) {
     });
 
     const automationControls = document.getElementById('automation-controls');
-    const automationBranchesList = document.getElementById('automation-branches-list');
     const automationCanvas = document.getElementById('automation-canvas');
 
     const observerConfig = { attributes: true, childList: true, subtree: true };


### PR DESCRIPTION
This commit introduces a new "Automation" tab in the footer of the DM controls view.

The new tab mirrors the layout and functionality of the main automation controls found in the "Story Beats" section.

Key changes:
- Added HTML structure and CSS for the new "Automation" tab and its content in `dm_view.html` and `dm_view.css`.
- Implemented JavaScript in `dm_view.js` to:
  - Dynamically render the controls in the new footer tab.
  - Proxy click events from the footer controls to the original controls in the main view, reusing existing logic.
  - Use a `MutationObserver` to watch for changes in the main automation section (e.g., branch selection, play/stop state) and synchronize the footer tab's UI to match.

This provides the user with quick access to automation controls from the main map view without needing to switch to the "Story Beats" tab.

Fixes bug where `automationBranchesList` was redeclared.