### PR TITLE
Fix: Address bugs in the Automation footer tab

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -12532,10 +12532,17 @@ function getDragAfterElement(container, y) {
             const li = e.target.closest('li');
             if (li) {
                 const branchName = li.querySelector('span').textContent;
-                const originalBranchList = document.getElementById('automation-branches-list');
-                const originalLi = Array.from(originalBranchList.querySelectorAll('li')).find(item => item.querySelector('span')?.textContent === branchName);
-                if (originalLi) {
-                    originalLi.click(); // This will trigger the original logic, including re-rendering the main canvas
+                if (automationBranches[branchName]) {
+                    loadAndRenderAutomationBranch(branchName);
+
+                    // Manually update selection in the main list to keep UI in sync
+                    const mainList = document.getElementById('automation-branches-list');
+                    if (mainList) {
+                        const currentSelected = mainList.querySelector('.selected');
+                        if (currentSelected) currentSelected.classList.remove('selected');
+                        const liToSelect = Array.from(mainList.querySelectorAll('li')).find(item => item.querySelector('span')?.textContent === branchName);
+                        if (liToSelect) liToSelect.classList.add('selected');
+                    }
                 }
             }
         });
@@ -12811,15 +12818,28 @@ function getDragAfterElement(container, y) {
             listItem.appendChild(deleteBtn);
 
             listItem.addEventListener('click', () => {
+                // Add selection logic here
+                const currentSelected = automationBranchesList.querySelector('.selected');
+                if (currentSelected) currentSelected.classList.remove('selected');
+                listItem.classList.add('selected');
+
                 if (confirm(`This will replace the current automation canvas. Are you sure you want to load the "${branchName}" branch?`)) {
-                    automationCanvasData = JSON.parse(JSON.stringify(automationBranches[branchName]));
-                    renderAutomationCanvasFromData();
+                    loadAndRenderAutomationBranch(branchName);
+                } else {
+                    // Revert selection on cancel
+                    listItem.classList.remove('selected');
                 }
             });
 
             automationBranchesList.appendChild(listItem);
         }
     }
+
+function loadAndRenderAutomationBranch(branchName) {
+    if (!automationBranches[branchName]) return;
+    automationCanvasData = JSON.parse(JSON.stringify(automationBranches[branchName]));
+    renderAutomationCanvasFromData();
+}
 
     if (saveAutomationBranchButton) {
         saveAutomationBranchButton.addEventListener('click', () => {


### PR DESCRIPTION
This commit resolves two issues with the "Automation" footer tab:
1.  Clicking a saved automation branch in the footer no longer causes the entire footer to minimize.
2.  The content of the footer tab (cards and "start/next" line) now correctly updates to reflect the selected branch, instead of always showing the "No automation branch selected" message.

These bugs were fixed by:
- Creating a new helper function, `loadAndRenderAutomationBranch`, to centralize the logic for loading an automation branch.
- Refactoring the `click` event listeners for both the main automation branch list and the new footer branch list to use this helper function.
- Removing the `confirm()` dialog from the footer's listener, which was causing the unexpected UI behavior.
- Adding logic to manually synchronize the selection state between the main and footer lists to ensure UI consistency.