### PR TITLE
fix: Resolve SyntaxError in handleNextAutomation

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -10112,9 +10112,6 @@ function displayToast(messageElement) {
             return;
         }
 
-        const notePreviewOverlay = document.getElementById('note-preview-overlay');
-        const characterPreviewOverlay = document.getElementById('character-preview-overlay');
-
         const historyEntry = {
             cardId: cardToActivate.dataset.cardId,
             previousState: {


### PR DESCRIPTION
This commit fixes a bug that caused a `SyntaxError: Identifier has already been declared` in the `handleNextAutomation` function.

The error was due to the duplicate declaration of the `notePreviewOverlay` and `characterPreviewOverlay` variables within the same function scope.

The fix removes the second, redundant declaration, resolving the error while preserving the intended functionality.