### PR TITLE
feat: Add settings button and overlay

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -495,6 +495,76 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
     color: #ffffff !important;
 }
 
+/* Settings Overlay */
+#settings-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1005; /* High z-index to be on top */
+}
+
+#settings-window {
+    width: 80%;
+    max-width: 900px;
+    height: 80%;
+    max-height: 600px;
+    background-color: #20262d;
+    border: 1px solid #3f4c5a;
+    border-radius: 8px;
+    display: flex;
+    overflow: hidden;
+}
+
+#settings-sidebar {
+    width: 200px;
+    background-color: #15191e;
+    padding: 15px;
+    border-right: 1px solid #3f4c5a;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.settings-category-button {
+    background: none;
+    border: none;
+    padding: 10px 15px;
+    cursor: pointer;
+    color: #e0e0e0;
+    font-size: 14px;
+    text-align: left;
+    border-radius: 4px;
+}
+
+.settings-category-button.active {
+    background-color: #3a4f6a;
+    font-weight: bold;
+}
+
+.settings-category-button:hover:not(.active) {
+    background-color: #2a3138;
+}
+
+#settings-content {
+    flex-grow: 1;
+    padding: 20px;
+    overflow-y: auto;
+}
+
+.settings-category-content {
+    display: none;
+}
+
+.settings-category-content.active {
+    display: block;
+}
+
 #automation-controls {
     text-align: center;
 }

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -65,6 +65,7 @@
             <div class="sidebar-section">
                 <h3>Player View</h3>
                 <button id="open-player-view-button">Open Player View</button>
+                <button id="settings-button" style="margin-top: 10px;">Settings</button>
             </div>
         </div>
 
@@ -246,6 +247,25 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="dm_view.js"></script>
     <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+
+    <div id="settings-overlay" style="display: none;">
+        <div id="settings-window">
+            <div id="settings-sidebar">
+                <button class="settings-category-button active" data-category="import-export">Import/Export</button>
+                <button class="settings-category-button" data-category="ai-features">AI Features</button>
+            </div>
+            <div id="settings-content">
+                <div class="settings-category-content active" id="import-export-content">
+                    <h2>Import/Export Settings</h2>
+                    <!-- Content for Import/Export settings -->
+                </div>
+                <div class="settings-category-content" id="ai-features-content">
+                    <h2>AI Features</h2>
+                    <!-- Content for AI features -->
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div id="polygon-context-menu" class="context-menu" style="display: none; position: absolute;">
         <ul>

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -13302,4 +13302,40 @@ function loadAndRenderAutomationBranch(branchName) {
     if (automationCanvas) {
         observer.observe(automationCanvas, observerConfig);
     }
+
+    // Settings Overlay Logic
+    const settingsButton = document.getElementById('settings-button');
+    const settingsOverlay = document.getElementById('settings-overlay');
+    const settingsWindow = document.getElementById('settings-window');
+    const settingsCategoryButtons = document.querySelectorAll('.settings-category-button');
+    const settingsCategoryContents = document.querySelectorAll('.settings-category-content');
+
+    if (settingsButton && settingsOverlay && settingsWindow) {
+        settingsButton.addEventListener('click', () => {
+            settingsOverlay.style.display = 'flex';
+        });
+
+        settingsOverlay.addEventListener('click', (event) => {
+            // If the click is on the overlay background, not the window itself
+            if (event.target === settingsOverlay) {
+                settingsOverlay.style.display = 'none';
+            }
+        });
+
+        settingsCategoryButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const category = button.dataset.category;
+
+                // Update button active state
+                settingsCategoryButtons.forEach(btn => {
+                    btn.classList.toggle('active', btn.dataset.category === category);
+                });
+
+                // Update content active state
+                settingsCategoryContents.forEach(content => {
+                    content.classList.toggle('active', content.id === `${category}-content`);
+                });
+            });
+        });
+    }
 });


### PR DESCRIPTION
This commit introduces a new settings button on the DM view, which opens a full-screen overlay.

The settings overlay includes a sidebar with categories for 'Import/Export' and 'AI Features', and a main content area to display the settings for the selected category.

The implementation includes:
- A 'Settings' button added to `dm_view.html`.
- The HTML structure for the settings overlay in `dm_view.html`.
- CSS styles for the overlay and its components in `dm_view.css`.
- JavaScript logic in `dm_view.js` to handle opening/closing the overlay and switching between categories.