### PR TITLE
feat: Add UI elements to Import/Export settings

### DIFF
--- a/Projects/DnDemicube/dm_view.css
+++ b/Projects/DnDemicube/dm_view.css
@@ -562,7 +562,68 @@ h3 { margin-top: 0; border-bottom: 1px solid #3f4c5a; padding-bottom: 5px;}
 }
 
 .settings-category-content.active {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#import-export-content h2 {
+    margin-top: 0;
+    flex-shrink: 0;
+}
+
+.import-export-controls {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+.import-export-controls button {
+    background-color: #3a4f6a;
+}
+
+.import-export-main {
+    display: flex;
+    flex-grow: 1;
+    gap: 15px;
+    min-height: 0; /* Important for flex children with overflow */
+}
+
+.import-export-list {
+    width: 30%;
+    border: 1px solid #3f4c5a;
+    border-radius: 4px;
+    overflow-y: auto;
+    background-color: #15191e;
+    padding: 5px;
+}
+
+.import-export-preview {
+    width: 70%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.import-export-preview textarea {
+    flex-grow: 1;
+    width: 100%;
+    resize: none;
+    background-color: #15191e;
+    border: 1px solid #3f4c5a;
+    color: #e0e0e0;
+    border-radius: 4px;
+    padding: 10px;
+    font-family: monospace;
+}
+
+.import-export-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-shrink: 0;
 }
 
 #automation-controls {

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -256,8 +256,26 @@
             </div>
             <div id="settings-content">
                 <div class="settings-category-content active" id="import-export-content">
-                    <h2>Import/Export Settings</h2>
-                    <!-- Content for Import/Export settings -->
+                    <div class="import-export-controls">
+                        <button data-type="all">All</button>
+                        <button data-type="characters">Characters</button>
+                        <button data-type="notes">Notes</button>
+                        <button data-type="story_beats">Story Beats</button>
+                        <button data-type="initiatives">Initiatives</button>
+                        <button data-type="automation">Automation</button>
+                    </div>
+                    <div class="import-export-main">
+                        <div class="import-export-list">
+                            <!-- Items will be populated here by JS -->
+                        </div>
+                        <div class="import-export-preview">
+                            <textarea readonly></textarea>
+                            <div class="import-export-buttons">
+                                <button id="save-export-button">Save</button>
+                                <button id="copy-export-button">Copy</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="settings-category-content" id="ai-features-content">
                     <h2>AI Features</h2>


### PR DESCRIPTION
This commit adds the UI elements to the 'Import/Export' section of the settings overlay, as requested by the user.

The new UI includes:
- A row of filter buttons at the top: 'All', 'Characters', 'Notes', 'Story Beats', 'Initiatives', and 'Automation'.
- A scrolling list area to display items.
- A large, scrolling text area for content preview.
- 'Save' and 'Copy' buttons at the bottom.

The implementation includes:
- The new HTML elements added to the `import-export-content` div in `dm_view.html`.
- CSS styles in `dm_view.css` to ensure the new elements are laid out correctly and match the application's theme.