### PR TITLE
Fix: Isolate Token HP from Original Character

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -6323,10 +6323,12 @@ function getTightBoundingBox(img) {
                             const newHp = currentHp - totalSum;
                             targetCharacter.sheetData.hp_current = newHp;
 
-                            const mainCharacter = charactersData.find(c => c.id === targetCharacter.id);
-                            if (mainCharacter) {
-                                if (!mainCharacter.sheetData) mainCharacter.sheetData = {};
-                                mainCharacter.sheetData.hp_current = newHp;
+                            if (!targetCharacter.isTokenCopy) {
+                                const mainCharacter = charactersData.find(c => c.id === targetCharacter.id);
+                                if (mainCharacter) {
+                                    if (!mainCharacter.sheetData) mainCharacter.sheetData = {};
+                                    mainCharacter.sheetData.hp_current = newHp;
+                                }
                             }
 
                             addLogEntry({
@@ -6356,10 +6358,12 @@ function getTightBoundingBox(img) {
                             const newHp = currentHp + totalSum;
                             targetCharacter.sheetData.hp_current = newHp;
 
-                            const mainCharacter = charactersData.find(c => c.id === targetCharacter.id);
-                            if (mainCharacter) {
-                                if (!mainCharacter.sheetData) mainCharacter.sheetData = {};
-                                mainCharacter.sheetData.hp_current = newHp;
+                            if (!targetCharacter.isTokenCopy) {
+                                const mainCharacter = charactersData.find(c => c.id === targetCharacter.id);
+                                if (mainCharacter) {
+                                    if (!mainCharacter.sheetData) mainCharacter.sheetData = {};
+                                    mainCharacter.sheetData.hp_current = newHp;
+                                }
                             }
 
                             addLogEntry({


### PR DESCRIPTION
This commit fixes a bug where temporary token copies in the initiative tracker were incorrectly updating the master character sheet's health.

- The damage and healing logic in the `tokenStatBlockRollsList` event listener is now conditional.
- Updates to the master `charactersData` array are now skipped if the character receiving the HP change has the `isTokenCopy` flag set to `true`.
- This ensures that token copies are fully independent and do not affect the original character's stats.