### PR TITLE
Fix story beat editing and add validation to data import

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -13670,7 +13670,8 @@ function loadAndRenderAutomationBranch(branchName) {
             // If a single item is selected in the list, we are updating that specific item.
             if (selectedListItem && !Array.isArray(parsedData)) {
                 const friendlyId = selectedListItem.dataset.id;
-                const internalId = importExportIdMaps.reverse[saveType] ? importExportIdMaps.reverse[saveType][friendlyId] : null;
+                const mapType = saveType === 'story-beats' ? 'quests' : saveType;
+                const internalId = importExportIdMaps.reverse[mapType] ? importExportIdMaps.reverse[mapType][friendlyId] : null;
 
                 if (internalId) {
                     // The user is editing a known item. We force the ID to match the original internal ID.
@@ -13765,6 +13766,16 @@ function loadAndRenderAutomationBranch(branchName) {
                     quests = data;
                     alert(`All story beats have been overwritten.`);
                 } else if (saveType === 'initiatives') {
+                    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+                        alert("Invalid format for Initiatives. It should be an object mapping names to arrays of participants.");
+                        return;
+                    }
+                    for (const key in data) {
+                        if (!Array.isArray(data[key])) {
+                            alert(`Invalid format for initiative "${key}". It should be an array of participants.`);
+                            return;
+                        }
+                    }
                     savedInitiatives = data;
                     alert(`All saved initiatives have been overwritten.`);
                 } else if (saveType === 'automation') {


### PR DESCRIPTION
This commit addresses two issues in the settings import/export section:

1.  When a user edits the details of a story beat via the JSON editor, the application would incorrectly prompt to create a new story beat instead of updating the existing one. This was caused by a key mismatch where the application was looking for a `story-beats` data type but the internal mapping used `quests`. The code has been updated to correctly map `story-beats` to `quests` during the save operation.

2.  Importing a JSON file with a valid format but incorrect data structure could crash the application. For example, if the value for an initiative was an object instead of an array, a `TypeError` would occur. Validation has been added to the import process for initiatives to ensure the data structure is correct before it is saved, preventing such crashes.