### PR TITLE
feat: Redesign settings import/export feature

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -285,10 +285,7 @@
             </div>
             <div id="settings-content">
                 <div class="settings-category-content active" id="import-export-content">
-                    <div id="import-export-loader">
-                        <div class="loader"></div>
-                    </div>
-                    <div class="import-export-controls" style="display: none;">
+                    <div class="import-export-controls">
                         <button data-type="all">All</button>
                         <button data-type="characters">Characters</button>
                         <button data-type="notes">Notes</button>
@@ -296,7 +293,7 @@
                         <button data-type="initiatives">Initiatives</button>
                         <button data-type="automation">Automation</button>
                     </div>
-                    <div class="import-export-main" style="display: none;">
+                    <div class="import-export-main">
                         <div class="import-export-list">
                             <!-- Items will be populated here by JS -->
                         </div>


### PR DESCRIPTION
This commit completely redesigns the settings import/export feature to work with raw JSON data, as requested.

The previous implementation, which translated internal data to a more user-friendly format, has been removed. The new implementation allows users to directly view and edit the raw JSON for different parts of the campaign data (Notes, Characters, Initiatives, etc.).

Key changes:
- Removed the `generateUserFriendlyData` and `revertToInternalIds` functions, which were responsible for the old translation logic.
- The import/export sidebar now displays a list of items for each category (e.g., a list of note titles).
- Clicking an item in the sidebar loads its raw, untranslated JSON into a CodeMirror editor.
- The "All" category now displays stats in the sidebar and the JSON for the entire campaign data in the editor.
- The "Save" button has been updated to parse the JSON from the editor and apply the changes directly to the application's data state.
- The UI has been updated to reflect these changes, removing the unnecessary loader and simplifying the layout.