### PR TITLE
Fix DM view bugs and add cursor style for link tool

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -3144,6 +3144,7 @@ function getTightBoundingBox(img) {
                 btnLinkChildMap.textContent = 'Cancel Drawing Link';
                 drawingCanvas.style.pointerEvents = 'auto';
                 dmCanvas.style.cursor = 'crosshair';
+                drawingCanvas.style.cursor = 'crosshair';
                 alert("Click on the map to start drawing a polygon for the link. Click the first point to close the shape.");
                 updateButtonStates();
             }


### PR DESCRIPTION
This commit addresses several issues in the DM view:

1.  **Fix custom roll saving from character sheet:** Custom rolls saved from the character sheet now persist correctly by calling `propagateCharacterUpdate()` to sync the data.

2.  **Add initiative/wander controls when footer is closed:** Quick-access controls for initiative and wandering are now available next to the d20 icon when the main footer is closed, improving usability during gameplay.

3.  **Fix context menu closing behavior:** The "Reset Fog of War" context menu on the map now closes correctly when clicking elsewhere on the screen.

4.  **Update cursor for 'link child map' tool:** The cursor now changes to a crosshair when using the 'link child map' tool, providing better visual feedback to the user.