### PR TITLE
feat: Add configurable grid overlay to maps

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -144,6 +144,7 @@
                 <button id="btn-assets-select">Select</button>
                 <button id="btn-assets-stamp">Stamp</button>
                 <button id="btn-assets-chain">Chain</button>
+                <button id="btn-assets-grid">Grid</button>
                 <button id="btn-assets-delete">Delete</button>
                 <button id="btn-assets-flatten">Flatten</button>
                 <button id="btn-assets-merge" style="display: none;">Merge</button>
@@ -177,9 +178,25 @@
                     <label for="asset-chain-points">Chain Points</label>
                     <input type="range" id="asset-chain-points" min="0" max="100" step="1" value="0">
                 </div>
+                <div id="grid-controls-container" style="display: none; margin-top: 10px; border-top: 1px solid #4a5f7a; padding-top: 10px;">
+                    <div class="asset-preview-slider-container">
+                        <label for="grid-scale-slider">Grid Scale</label>
+                        <input type="range" id="grid-scale-slider" min="1" max="200" step="1" value="50">
+                        <span id="grid-scale-value">50</span>
+                    </div>
+                    <div class="asset-preview-slider-container">
+                        <label for="grid-sqft-input" style="white-space: nowrap;">sqft/grid</label>
+                        <input type="number" id="grid-sqft-input" value="5" style="width: 60px; text-align: center; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0;">
+                    </div>
+                    <div class="asset-preview-slider-container">
+                        <label for="grid-on-checkbox" style="white-space: nowrap;">Grid On</label>
+                        <input type="checkbox" id="grid-on-checkbox" style="margin-left: 5px;">
+                    </div>
+                </div>
             </div>
         </div>
         <canvas id="dm-canvas"></canvas>
+        <canvas id="grid-canvas"></canvas>
         <canvas id="shadow-canvas"></canvas>
         <canvas id="drawing-canvas"></canvas>
     </div>

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -235,6 +235,7 @@
     <div id="player-map-container">
         <canvas id="player-canvas"></canvas>
         <canvas id="player-shadow-canvas" style="pointer-events: none;"></canvas>
+        <canvas id="grid-canvas" style="pointer-events: none;"></canvas>
         <canvas id="fog-canvas" style="pointer-events: none;"></canvas>
         <div id="dice-roller-icon" class="absolute bottom-5 right-5 w-12 h-12 cursor-pointer z-10">
             <img src="assets/d20icon.png" alt="d20 icon" class="w-full h-full">


### PR DESCRIPTION
This commit introduces a new grid overlay feature accessible from the "Assets" tool in the DM's view.

Key features include:
- A "Grid" button in the asset tools that toggles the grid controls.
- A scale slider to adjust the size of the grid cells.
- An input field to set a "sqft/grid" reference for measurement.
- A checkbox to control the visibility of the grid for both the DM and the player.

The grid is drawn on a separate canvas for performance and is synchronized in real-time with the player's view. The grid settings are saved on a per-map basis and are included in the campaign save/load functionality, ensuring persistence across sessions.