### PR TITLE
fix: Address issues with grid overlay feature

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -178,27 +178,27 @@
                     <label for="asset-chain-points">Chain Points</label>
                     <input type="range" id="asset-chain-points" min="0" max="100" step="1" value="0">
                 </div>
-                <div id="grid-controls-container" style="display: none; margin-top: 10px; border-top: 1px solid #4a5f7a; padding-top: 10px;">
-                    <div class="asset-preview-slider-container">
-                        <label for="grid-scale-slider">Grid Scale</label>
-                        <input type="range" id="grid-scale-slider" min="1" max="200" step="1" value="50">
-                        <span id="grid-scale-value">50</span>
-                    </div>
-                    <div class="asset-preview-slider-container">
-                        <label for="grid-sqft-input" style="white-space: nowrap;">sqft/grid</label>
-                        <input type="number" id="grid-sqft-input" value="5" style="width: 60px; text-align: center; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0;">
-                    </div>
-                    <div class="asset-preview-slider-container">
-                        <label for="grid-on-checkbox" style="white-space: nowrap;">Grid On</label>
-                        <input type="checkbox" id="grid-on-checkbox" style="margin-left: 5px;">
-                    </div>
+            </div>
+            <div id="grid-controls-container" style="display: none; margin-top: 10px; border-top: 1px solid #4a5f7a; padding-top: 10px;">
+                <div class="asset-preview-slider-container">
+                    <label for="grid-scale-slider">Grid Scale</label>
+                    <input type="range" id="grid-scale-slider" min="1" max="200" step="1" value="50">
+                    <span id="grid-scale-value">50</span>
+                </div>
+                <div class="asset-preview-slider-container">
+                    <label for="grid-sqft-input" style="white-space: nowrap;">sqft/grid</label>
+                    <input type="number" id="grid-sqft-input" value="5" style="width: 60px; text-align: center; background-color: #15191e; border: 1px solid #3f4c5a; color: #e0e0e0;">
+                </div>
+                <div class="asset-preview-slider-container">
+                    <label for="grid-on-checkbox" style="white-space: nowrap;">Grid On</label>
+                    <input type="checkbox" id="grid-on-checkbox" style="margin-left: 5px;">
                 </div>
             </div>
         </div>
-        <canvas id="dm-canvas"></canvas>
-        <canvas id="grid-canvas"></canvas>
-        <canvas id="shadow-canvas"></canvas>
-        <canvas id="drawing-canvas"></canvas>
+        <canvas id="dm-canvas" style="z-index: 1;"></canvas>
+        <canvas id="grid-canvas" style="z-index: 2; pointer-events: none;"></canvas>
+        <canvas id="shadow-canvas" style="z-index: 3; pointer-events: none;"></canvas>
+        <canvas id="drawing-canvas" style="z-index: 4; pointer-events: none;"></canvas>
     </div>
     <div id="automation-container" style="display: none; width: 100%;">
         <div id="modules-sidebar">

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -4802,7 +4802,7 @@ function getTightBoundingBox(img) {
             const mapData = detailedMapData.get(selectedMapFileName);
             if (!mapData) return;
 
-            if (!activeAssetTool) { // Prevent panning if an asset tool is active
+            if (!activeAssetTool && !isGridToolActive) { // Prevent panning if an asset tool or grid tool is active
                 isPanning = true;
                 panStartX = e.clientX - mapData.transform.originX;
                 panStartY = e.clientY - mapData.transform.originY;


### PR DESCRIPTION
This commit fixes several issues with the recently implemented grid overlay feature:

1.  **Grid Tool Visibility:** The grid controls are now independent of the asset preview pane and are correctly displayed whenever the grid tool is active. This was achieved by moving the `grid-controls-container` out of the `asset-preview-container` in `dm_view.html`.
2.  **Panning Disabled:** Map panning is now correctly disabled when the grid tool is active, preventing accidental map movement while using the grid control sliders.
3.  **Grid Rendering:** The grid now renders correctly. The canvas layers have been explicitly ordered using `z-index` in `dm_view.html` to ensure the grid canvas is visible above the map canvas.

These changes ensure the grid feature is fully functional and provides a better user experience.