### PR TITLE
feat: Add synchronized vision range input

### DIFF
--- a/Projects/DnDemicube/character_sheet.html
+++ b/Projects/DnDemicube/character_sheet.html
@@ -22,7 +22,7 @@
                     <input type="checkbox" id="details-visibility-toggle" name="details_visibility_toggle" checked>
                     <label for="details-visibility-toggle" style="font-size: 0.8em;">Show Details to Players</label>
                 </div>
-                <div class="vision-controls" style="margin-top: 5px; text-align: center; font-size: 0.8em;">
+                <div id="vision-controls" class="vision-controls" style="margin-top: 5px; text-align: center; font-size: 0.8em;">
                     <input type="checkbox" id="vision-checkbox" name="vision" checked>
                     <label for="vision-checkbox">Vision</label>
                     <input type="number" id="vision-ft-input" name="vision_ft" style="width: 40px;" value="0">

--- a/Projects/DnDemicube/character_sheet.js
+++ b/Projects/DnDemicube/character_sheet.js
@@ -125,6 +125,16 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    const visionFtInput = document.getElementById('vision-ft-input');
+    if (visionFtInput) {
+        visionFtInput.addEventListener('input', function() {
+            window.parent.postMessage({
+                type: 'characterVisionFtChange',
+                visionRange: this.value
+            }, '*');
+        });
+    }
+
     savingThrowAttrs.forEach(createSavingThrow);
     for (const skill in skills) {
         createSkill(skill, skills[skill]);
@@ -179,6 +189,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 input.value = '';
             }
         });
+        document.getElementById('vision-ft-input').value = '60';
+        document.getElementById('vision-checkbox').checked = true;
     }
 
     const detailsVisibilityToggle = document.getElementById('details-visibility-toggle');
@@ -358,6 +370,9 @@ document.addEventListener('DOMContentLoaded', function() {
         if (event.data.type === 'loadCharacterSheet') {
             clearSheetFields();
             const data = event.data.data;
+            if (typeof data.vision_ft === 'undefined' || data.vision_ft === null || data.vision_ft === '') {
+                data.vision_ft = '60';
+            }
             for (const key in data) {
                 const element = document.getElementsByName(key)[0];
                 if (element) {
@@ -389,6 +404,11 @@ document.addEventListener('DOMContentLoaded', function() {
         } else if (event.data.type === 'characterVisionChange_from_dm') {
             if (visionCheckbox) {
                 visionCheckbox.checked = event.data.vision;
+            }
+        } else if (event.data.type === 'characterVisionFtChange_from_dm') {
+            const visionFtInput = document.getElementById('vision-ft-input');
+            if (visionFtInput) {
+                visionFtInput.value = event.data.visionRange;
             }
         } else if (event.data.type === 'requestSheetData') {
             const sheetData = {};

--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -617,6 +617,8 @@
                 <div>
                     <input type="checkbox" id="token-stat-block-vision-toggle">
                     <label for="token-stat-block-vision-toggle">Vision</label>
+                    <input type="number" id="token-stat-block-vision-ft-input" style="width: 40px;" value="0">
+                    <label for="token-stat-block-vision-ft-input">ft</label>
                 </div>
             </div>
             <div class="stat-block-health">


### PR DESCRIPTION
Adds a synchronized 'ft' input for vision range to both the character sheet and the token overlay menu.

Key features:
- Defaults new character vision to 60ft.
- Changes to the vision range are synchronized between the character sheet and the token overlay for the master character.
- Changes to "copy tokens" do not affect the master character sheet.
- Maintains backward compatibility with existing save/upload functionality.