### PR TITLE
feat: Add context menu for light source vision

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -377,6 +377,19 @@
         </ul>
     </div>
 
+    <div id="light-source-context-menu" class="context-menu" style="display: none; position: absolute;">
+        <ul>
+            <li>
+                <label for="light-source-vision-toggle">Vision</label>
+                <input type="checkbox" id="light-source-vision-toggle">
+            </li>
+            <li>
+                <label for="light-source-vision-ft-input">ft</label>
+                <input type="number" id="light-source-vision-ft-input" style="width: 50px;">
+            </li>
+        </ul>
+    </div>
+
     <div id="note-preview-overlay" class="note-preview-overlay" style="display: none;">
         <div class="note-preview-content">
             <button id="note-preview-close" class="note-preview-close">&times;</button>


### PR DESCRIPTION
Adds a context menu for light sources on the map, allowing their vision range to be edited.

Key features:
- Light sources now have unique IDs and default to 20ft of vision.
- Right-clicking a light source in active mode opens a context menu with a vision toggle and a 'ft' input.
- The context menu is exclusive and does not trigger other menus.
- The `drawOverlays` function is updated to use the new `vision_ft` property to determine the light source radius.