### PR TITLE
feat: Add context menu for light source vision and fix radius logic

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1711,7 +1711,7 @@ function getTightBoundingBox(img) {
             } else if (overlay.type === 'lightSource' && overlay.position) {
                 const canvasX = (overlay.position.x * scale) + originX;
                 const canvasY = (overlay.position.y * scale) + originY;
-                const radius = (overlay.vision_ft || 20) / (gridData[selectedMapFileName]?.sqft || 5) * (gridData[selectedMapFileName]?.scale || 50) * scale;
+                const radius = (overlay.radius || 15) * scale;
                 drawingCtx.fillStyle = 'rgba(255, 255, 0, 0.7)';
                 drawingCtx.beginPath();
                 drawingCtx.arc(canvasX, canvasY, radius, 0, Math.PI * 2);
@@ -3012,10 +3012,10 @@ function getTightBoundingBox(img) {
     }
 
     function isPointInLightSource(point, lightSource) {
-        const radius = (lightSource.vision_ft || 20) / (gridData[selectedMapFileName]?.sqft || 5) * (gridData[selectedMapFileName]?.scale || 50);
+        const radius = 15;
         const dx = point.x - lightSource.position.x;
         const dy = point.y - lightSource.position.y;
-        const distance = Math.sqrt(dx * dx + dy * dy) * (currentMapDisplayData.scale || 1);
+        const distance = Math.sqrt(dx * dx + dy * dy);
         return distance <= radius;
     }
 


### PR DESCRIPTION
Adds a context menu for light sources on the map, allowing their vision range to be edited. Also corrects the light source radius logic to use a fixed value.

Key features:
- Light sources now have unique IDs and default to 20ft of vision.
- Right-clicking a light source in active mode opens a context menu with a vision toggle and a 'ft' input.
- The context menu is exclusive and does not trigger other menus.
- The light source radius is now a fixed value and is not affected by the 'vision_ft' input, as per the user's request.