### PR TITLE
Fix: Light source menu only appears in active mode and closes on clic…

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -96,6 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const characterContextMenu = document.getElementById('character-context-menu');
     const mapToolsContextMenu = document.getElementById('map-tools-context-menu');
     const viewModeMapContextMenu = document.getElementById('view-mode-map-context-menu');
+    const lightSourceContextMenu = document.getElementById('light-source-context-menu');
     const displayedFileNames = new Set();
 
     // Shadow tool elements
@@ -6790,17 +6791,18 @@ function getTightBoundingBox(img) {
                     overlayClicked = true;
                     break;
                 } else if (overlay.type === 'lightSource' && isPointInLightSource(imageCoords, overlay)) {
-                    selectedLightSourceForContextMenu = overlay;
-                    const lightSourceContextMenu = document.getElementById('light-source-context-menu');
-                    const visionToggle = document.getElementById('light-source-vision-toggle');
-                    const visionFtInput = document.getElementById('light-source-vision-ft-input');
+                    if (selectedMapData.mode === 'view') {
+                        selectedLightSourceForContextMenu = overlay;
+                        const visionToggle = document.getElementById('light-source-vision-toggle');
+                        const visionFtInput = document.getElementById('light-source-vision-ft-input');
 
-                    visionToggle.checked = overlay.vision;
-                    visionFtInput.value = overlay.vision_ft;
+                        visionToggle.checked = overlay.vision;
+                        visionFtInput.value = overlay.vision_ft;
 
-                    lightSourceContextMenu.style.left = `${event.pageX}px`;
-                    lightSourceContextMenu.style.top = `${event.pageY}px`;
-                    lightSourceContextMenu.style.display = 'block';
+                        lightSourceContextMenu.style.left = `${event.pageX}px`;
+                        lightSourceContextMenu.style.top = `${event.pageY}px`;
+                        lightSourceContextMenu.style.display = 'block';
+                    }
                     overlayClicked = true;
                     break;
                 }
@@ -6863,6 +6865,7 @@ function getTightBoundingBox(img) {
             (characterContextMenu.style.display === 'block' && characterContextMenu.contains(event.target)) ||
             (mapToolsContextMenu.style.display === 'block' && mapToolsContextMenu.contains(event.target)) ||
             (viewModeMapContextMenu.style.display === 'block' && viewModeMapContextMenu.contains(event.target)) ||
+            (lightSourceContextMenu.style.display === 'block' && lightSourceContextMenu.contains(event.target)) ||
             Array.from(document.querySelectorAll('.dynamic-context-menu')).some(menu => menu.contains(event.target));
 
 
@@ -6872,6 +6875,7 @@ function getTightBoundingBox(img) {
             characterContextMenu.style.display = 'none';
             mapToolsContextMenu.style.display = 'none';
             viewModeMapContextMenu.style.display = 'none';
+            lightSourceContextMenu.style.display = 'none';
             document.querySelectorAll('.dynamic-context-menu').forEach(menu => menu.remove());
 
             // Reset selection states


### PR DESCRIPTION
…k-off

The light source context menu was appearing in all modes and did not close when clicking outside of it.

This commit fixes this behavior by:
- Adding a check to ensure the menu only appears when the map is in 'view' (active) mode.
- Updating the global click listener to also close the light source context menu.