### PR TITLE
Fix: Light source context menu visibility and closing behavior

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -96,7 +96,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const characterContextMenu = document.getElementById('character-context-menu');
     const mapToolsContextMenu = document.getElementById('map-tools-context-menu');
     const viewModeMapContextMenu = document.getElementById('view-mode-map-context-menu');
-    const lightSourceContextMenu = document.getElementById('light-source-context-menu');
     const displayedFileNames = new Set();
 
     // Shadow tool elements


### PR DESCRIPTION
- The light source context menu will now only appear when the map is in 'view' (active) mode.
- Clicking outside of the light source context menu will now correctly close it.
- This also resolves a JavaScript syntax error where 'lightSourceContextMenu' was declared twice.