### PR TITLE
feat: Implement grid-based vision radius

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1903,11 +1903,15 @@ function getTightBoundingBox(img) {
         const dmLightSources = mapData.overlays.filter(o => o.type === 'lightSource');
         const tokenLightSources = initiativeTokens
             .filter(token => token.isDetailsVisible !== false)
-            .map(token => ({
-                type: 'lightSource',
-                position: { x: token.x, y: token.y },
-                radius: 40 // A reasonable default radius for a token
-            }));
+            .map(token => {
+                const character = charactersData.find(c => c.id === token.characterId);
+                return {
+                    type: 'lightSource',
+                    position: { x: token.x, y: token.y },
+                    radius: 40, // A reasonable default radius for a token
+                    character: character
+                };
+            });
         const lightSources = [...dmLightSources, ...tokenLightSources];
         const walls = mapData.overlays.filter(o => o.type === 'wall');
         const closedDoors = mapData.overlays.filter(o => o.type === 'door' && !o.isOpen);
@@ -1951,7 +1955,7 @@ function getTightBoundingBox(img) {
             const currentGridData = gridData[selectedMapFileName];
             let visionRadiusInPixels = null;
 
-            if (currentGridData && currentGridData.visible) {
+            if (character && character.sheetData && currentGridData && currentGridData.visible) {
                 const visionFt = parseInt(character.sheetData.vision_ft, 10) || 0;
                 const gridSqft = parseInt(currentGridData.sqft, 10) || 5;
                 const gridScale = parseInt(currentGridData.scale, 10);


### PR DESCRIPTION
This commit introduces a new behavior for the character vision system.

When a map has a grid enabled, the vision circle for a character's token is now restricted by their vision range in feet, scaled according to the grid's settings (feet per square). This provides a more accurate representation of character senses based on D&D rules.

When a map does not have a grid, the vision system retains its original behavior, expanding until it hits an obstacle.

The changes were implemented in the `recalculateLightMap` function in `dm_view.js`. This involved:
- Attaching character data to token-based light sources.
- Calculating the vision radius in pixels when a grid is active.
- Capping the vision raycasting at this calculated radius, while still allowing it to be blocked by walls and other obstacles.
- Ensuring that static, non-character light sources are not affected and continue to function as before.