### PR TITLE
Fix: Player view now correctly hides map in edit mode

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -644,11 +644,18 @@ window.addEventListener('message', (event) => {
                 slideshowPlaylist = data.playlist;
                 currentSlideIndex = data.startIndex || 0;
 
+                slideshowActive = true;
+                playerMapContainer.style.display = 'none';
+                slideshowContainer.style.display = 'flex';
+
                 if (slideshowPlaylist && slideshowPlaylist.length > 0) {
-                    slideshowActive = true;
-                    playerMapContainer.style.display = 'none';
-                    slideshowContainer.style.display = 'flex';
                     animateSlideshow();
+                } else {
+                    // Display a placeholder message if there's no playlist
+                    portraitImg.style.display = 'none';
+                    portraitInitials.style.display = 'none';
+                    authorText.textContent = '';
+                    quoteText.textContent = "The DM is currently editing the map...";
                 }
                 break;
             case 'loadMap':


### PR DESCRIPTION
The player view was not being hidden when the DM entered edit mode. This was because the slideshow would only be displayed if a playlist of character quotes could be generated.

This change modifies the `startSlideshow` message handler in `player_view.js` to always hide the map container and show the slideshow container when the DM enters edit mode. If no character quotes are available, a placeholder message is displayed instead.

This ensures the player's view is always hidden during DM edits, as intended.