### PR TITLE
Fix(vision): Correct darkvision clipping and add light source dimming

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -359,6 +359,23 @@
         </ul>
     </div>
 
+        <!-- Light Source Context Menu -->
+        <div id="light-source-context-menu" class="context-menu" style="display: none;">
+            <ul>
+                <li style="padding-bottom: 5px;">
+                    <label style="display: flex; align-items: center; cursor: pointer;">
+                        <input type="checkbox" id="dimlight-checkbox" style="margin-right: 8px;"> Vision
+                    </label>
+                </li>
+                <li style="padding-top: 5px;">
+                    <label>
+                        Radius: <input type="number" id="dimlight-radius-input" style="width: 50px; margin-left: 5px;"> ft
+                    </label>
+                </li>
+                <li data-action="delete-light-source" style="border-top: 1px solid #4a5568; margin-top: 8px; padding-top: 8px; cursor: pointer;">Delete Light Source</li>
+            </ul>
+        </div>
+
     <div id="character-context-menu" class="context-menu" style="display: none; position: absolute;">
         <ul>
             <li data-action="link-to-character">Link to Character</li>

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -310,13 +310,56 @@ function getLineIntersection(p1, p2) {
     return null;
 }
 
+function getLosPolygon(lightPos, allSegments, allVertices, imgWidth, imgHeight) {
+    const visiblePoints = [];
+    const angles = new Set();
+    const lightIsInsideObject = false; // Simplified for player view
+
+    allVertices.forEach(vertex => {
+        const angle = Math.atan2(vertex.y - lightPos.y, vertex.x - lightPos.x);
+        angles.add(angle - 0.0001);
+        angles.add(angle);
+        angles.add(angle + 0.0001);
+    });
+
+    const sortedAngles = Array.from(angles).sort((a, b) => a - b);
+
+    sortedAngles.forEach(angle => {
+        const ray = {
+            x1: lightPos.x,
+            y1: lightPos.y,
+            x2: lightPos.x + (imgWidth + imgHeight) * 2 * Math.cos(angle),
+            y2: lightPos.y + (imgWidth + imgHeight) * 2 * Math.sin(angle)
+        };
+
+        let closestIntersection = null;
+        let minDistance = Infinity;
+
+        allSegments.forEach(segment => {
+            const intersectionPoint = getLineIntersection(ray, { x1: segment.p1.x, y1: segment.p1.y, x2: segment.p2.x, y2: segment.p2.y });
+            if (intersectionPoint) {
+                const distance = Math.sqrt(Math.pow(intersectionPoint.x - lightPos.x, 2) + Math.pow(intersectionPoint.y - lightPos.y, 2));
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    closestIntersection = intersectionPoint;
+                }
+            }
+        });
+
+        if (closestIntersection) {
+            visiblePoints.push(closestIntersection);
+        } else {
+            visiblePoints.push({ x: ray.x2, y: ray.y2 });
+        }
+    });
+    return visiblePoints;
+}
+
 function recalculateLightMap_Player() {
     if (!isLightMapDirty) return;
 
     if (!currentMapDisplayData.img) {
-        if (lightMapCtx) {
-            lightMapCtx.clearRect(0, 0, lightMapCanvas.width, lightMapCanvas.height);
-        }
+        if (lightMapCtx) lightMapCtx.clearRect(0, 0, lightMapCanvas.width, lightMapCanvas.height);
         isLightMapDirty = false;
         return;
     }
@@ -443,18 +486,51 @@ function recalculateLightMap_Player() {
             }
         });
 
-        lightMapCtx.save();
-        lightMapCtx.globalCompositeOperation = 'destination-out';
-        lightMapCtx.beginPath();
+            const tempLightCanvas = document.createElement('canvas');
+            tempLightCanvas.width = lightMapCanvas.width;
+            tempLightCanvas.height = lightMapCanvas.height;
+            const tempLightCtx = tempLightCanvas.getContext('2d');
+
+            tempLightCtx.fillStyle = 'black';
+            tempLightCtx.beginPath();
         if (visiblePoints.length > 0) {
             const firstPoint = visiblePoints[0];
-            lightMapCtx.moveTo(firstPoint.x * lightScale, firstPoint.y * lightScale);
+                tempLightCtx.moveTo(firstPoint.x * lightScale, firstPoint.y * lightScale);
             visiblePoints.forEach(point => {
-                lightMapCtx.lineTo(point.x * lightScale, point.y * lightScale);
+                    tempLightCtx.lineTo(point.x * lightScale, point.y * lightScale);
             });
-            lightMapCtx.closePath();
-            lightMapCtx.fill();
+                tempLightCtx.closePath();
+                tempLightCtx.fill();
         }
+
+            if (light.dimlight_enabled) {
+                if (currentGridData && currentGridData.visible) {
+                    const radiusFt = light.dimlight_radius_ft || 0;
+                    const gridSqftValue = currentGridData.sqft || 5;
+                    const gridPixelSize = currentGridData.scale || 50;
+
+                    if (radiusFt > 0 && gridSqftValue > 0) {
+                        const radiusInGridSquares = radiusFt / gridSqftValue;
+                        const radiusInPixels = radiusInGridSquares * gridPixelSize;
+
+                        const dimlightMaskCanvas = document.createElement('canvas');
+                        dimlightMaskCanvas.width = lightMapCanvas.width;
+                        dimlightMaskCanvas.height = lightMapCanvas.height;
+                        const maskCtx = dimlightMaskCanvas.getContext('2d');
+                        maskCtx.fillStyle = 'black';
+                        maskCtx.beginPath();
+                        maskCtx.arc(light.position.x * lightScale, light.position.y * lightScale, radiusInPixels * lightScale, 0, Math.PI * 2, true);
+                        maskCtx.fill();
+
+                        tempLightCtx.globalCompositeOperation = 'source-in';
+                        tempLightCtx.drawImage(dimlightMaskCanvas, 0, 0);
+                    }
+                }
+            }
+
+            lightMapCtx.save();
+            lightMapCtx.globalCompositeOperation = 'destination-out';
+            lightMapCtx.drawImage(tempLightCanvas, 0, 0);
         lightMapCtx.restore();
     });
 


### PR DESCRIPTION
This commit addresses a bug where token vision was not being correctly restricted by the darkvision radius in the real-time shadow calculation. It also introduces two major feature enhancements to the vision system.

- Fixes a bug where a token's real-time shadow reveal was not clipped by its darkvision circle. The logic now correctly intersects the token's line-of-sight with its darkvision radius, matching the behavior of the permanent fog of war.

- Tokens can now see brightly lit areas that are outside their darkvision circle but still within their line-of-sight. The new vision calculation unions the token's darkvision with a map of all lit areas before intersecting with the line-of-sight.

- Adds a "dimlight" feature for light sources. A new context menu allows the DM to set a vision radius on a light source, restricting the area it illuminates. This uses the same clipping logic developed for the darkvision fix.

- Ensures backward compatibility with older campaign save files by adding default values for the new dimlight properties upon loading.