### PR TITLE
Fix(darkvision): Restrict real-time shadow reveal to vision radius

### DIFF
--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1898,6 +1898,189 @@ function getTightBoundingBox(img) {
         return null;
     }
 
+    function createDarkvisionMask() {
+        const mapGridData = gridData[selectedMapFileName];
+        if (!mapGridData || !mapGridData.visible || !currentMapDisplayData.img) {
+            return null;
+        }
+
+        const darkvisionMaskCanvas = document.createElement('canvas');
+        darkvisionMaskCanvas.width = currentMapDisplayData.imgWidth;
+        darkvisionMaskCanvas.height = currentMapDisplayData.imgHeight;
+        const maskCtx = darkvisionMaskCanvas.getContext('2d');
+        maskCtx.fillStyle = 'black';
+
+        const tokensWithVision = initiativeTokens.filter(token => {
+            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
+            return character && character.vision === true;
+        });
+
+        if (tokensWithVision.length === 0) {
+            return null;
+        }
+
+        tokensWithVision.forEach(token => {
+            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
+            if (character && character.sheetData) {
+                const visionFt = parseInt(character.sheetData.vision_ft, 10) || 0;
+                const gridSqftValue = mapGridData.sqft || 5;
+                const gridPixelSize = mapGridData.scale || 50;
+
+                if (visionFt > 0 && gridSqftValue > 0) {
+                    const visionRadiusInGridSquares = visionFt / gridSqftValue;
+                    const visionRadiusInPixels = visionRadiusInGridSquares * gridPixelSize;
+
+                    maskCtx.beginPath();
+                    maskCtx.arc(token.x, token.y, visionRadiusInPixels, 0, Math.PI * 2, true);
+                    maskCtx.fill();
+                }
+            }
+        });
+
+        return darkvisionMaskCanvas;
+    }
+
+    function generateVisionMask() {
+        const mapData = detailedMapData.get(selectedMapFileName);
+        if (!mapData || !currentMapDisplayData.img) return null;
+
+        const visionMaskCanvas = document.createElement('canvas');
+        visionMaskCanvas.width = currentMapDisplayData.imgWidth;
+        visionMaskCanvas.height = currentMapDisplayData.imgHeight;
+        const visionCtx = visionMaskCanvas.getContext('2d');
+
+        const lightSources = initiativeTokens
+            .filter(token => {
+                const character = charactersData.find(c => c.id === token.characterId);
+                return character && character.vision === true;
+            })
+            .map(token => ({
+                position: { x: token.x, y: token.y }
+            }));
+
+        if (lightSources.length === 0) return null;
+
+        const walls = mapData.overlays.filter(o => o.type === 'wall');
+        const closedDoors = mapData.overlays.filter(o => o.type === 'door' && !o.isOpen);
+        const smartObjects = mapData.overlays.filter(o => o.type === 'smart_object');
+
+        const allSegments = [];
+        walls.forEach(wall => {
+            for (let i = 0; i < wall.points.length - 1; i++) {
+                allSegments.push({ p1: wall.points[i], p2: wall.points[i + 1], parent: wall });
+            }
+        });
+        closedDoors.forEach(door => {
+            allSegments.push({ p1: door.points[0], p2: door.points[1], parent: door });
+        });
+        smartObjects.forEach(object => {
+            for (let i = 0; i < object.polygon.length - 1; i++) {
+                allSegments.push({ p1: object.polygon[i], p2: object.polygon[i + 1], parent: object });
+            }
+             allSegments.push({ p1: object.polygon[object.polygon.length - 1], p2: object.polygon[0], parent: object });
+        });
+
+        const imgWidth = currentMapDisplayData.imgWidth;
+        const imgHeight = currentMapDisplayData.imgHeight;
+        allSegments.push({ p1: { x: 0, y: 0 }, p2: { x: imgWidth, y: 0 }, parent: { type: 'boundary' } });
+        allSegments.push({ p1: { x: imgWidth, y: 0 }, p2: { x: imgWidth, y: imgHeight }, parent: { type: 'boundary' } });
+        allSegments.push({ p1: { x: imgWidth, y: imgHeight }, p2: { x: 0, y: imgHeight }, parent: { type: 'boundary' } });
+        allSegments.push({ p1: { x: 0, y: imgHeight }, p2: { x: 0, y: 0 }, parent: { type: 'boundary' } });
+
+        const allVertices = [];
+        allSegments.forEach(seg => {
+            allVertices.push(seg.p1, seg.p2);
+        });
+
+        visionCtx.fillStyle = 'black';
+        visionCtx.beginPath();
+
+        lightSources.forEach(light => {
+            const visiblePoints = [];
+            const angles = new Set();
+
+            let lightIsInsideObject = false;
+            for (const so of smartObjects) {
+                if (isPointInPolygon(light.position, so.polygon)) {
+                    lightIsInsideObject = true;
+                    break;
+                }
+            }
+
+            allVertices.forEach(vertex => {
+                const angle = Math.atan2(vertex.y - light.position.y, vertex.x - light.position.x);
+                angles.add(angle - 0.0001);
+                angles.add(angle);
+                angles.add(angle + 0.0001);
+            });
+
+            const sortedAngles = Array.from(angles).sort((a, b) => a - b);
+
+            sortedAngles.forEach(angle => {
+                const ray = {
+                    x1: light.position.x,
+                    y1: light.position.y,
+                    x2: light.position.x + (imgWidth + imgHeight) * 2 * Math.cos(angle),
+                    y2: light.position.y + (imgWidth + imgHeight) * 2 * Math.sin(angle)
+                };
+
+                let closestIntersection = null;
+                let minDistance = Infinity;
+
+                allSegments.forEach(segment => {
+                    const intersectionPoint = getLineIntersection(ray, { x1: segment.p1.x, y1: segment.p1.y, x2: segment.p2.x, y2: segment.p2.y });
+                    if (intersectionPoint) {
+                        let ignoreThisIntersection = false;
+                        if (segment.parent.type === 'smart_object') {
+                            const p1 = segment.p1;
+                            const p2 = segment.p2;
+                            const normal = { x: p2.y - p1.y, y: p1.x - p2.x };
+                            const lightVector = { x: intersectionPoint.x - light.position.x, y: intersectionPoint.y - light.position.y };
+                            const dot = (lightVector.x * normal.x) + (lightVector.y * normal.y);
+                            if (!lightIsInsideObject && dot > 0) {
+                                ignoreThisIntersection = true;
+                            }
+                        }
+
+                        if (!ignoreThisIntersection) {
+                            const distance = Math.sqrt(Math.pow(intersectionPoint.x - light.position.x, 2) + Math.pow(intersectionPoint.y - light.position.y, 2));
+                            if (distance < minDistance) {
+                                minDistance = distance;
+                                closestIntersection = intersectionPoint;
+                            }
+                        }
+                    }
+                });
+
+                if (closestIntersection) {
+                    visiblePoints.push(closestIntersection);
+                } else {
+                    visiblePoints.push({ x: ray.x2, y: ray.y2 });
+                }
+            });
+
+            if (visiblePoints.length > 0) {
+                const firstPoint = visiblePoints[0];
+                visionCtx.moveTo(firstPoint.x, firstPoint.y);
+                visiblePoints.forEach(point => {
+                    visionCtx.lineTo(point.x, point.y);
+                });
+                visionCtx.closePath();
+            }
+        });
+        visionCtx.fill();
+
+        // If grid is on, clip the vision to the darkvision radius
+        const darkvisionMask = createDarkvisionMask();
+        if (darkvisionMask) {
+            visionCtx.globalCompositeOperation = 'source-in';
+            visionCtx.drawImage(darkvisionMask, 0, 0);
+            visionCtx.globalCompositeOperation = 'source-over'; // Reset for other operations
+        }
+
+        return visionMaskCanvas;
+    }
+
     let shadowAnimationId = null;
 
     function recalculateLightMap() {
@@ -2048,12 +2231,12 @@ function getTightBoundingBox(img) {
             lightMapCtx.restore();
         });
 
-        // If grid is on, clip the light map to the darkvision radius
-        const darkvisionMask = createDarkvisionMask();
-        if (darkvisionMask) {
-            lightMapCtx.globalCompositeOperation = 'source-in';
-            lightMapCtx.drawImage(darkvisionMask, 0, 0, lightMapCanvas.width, lightMapCanvas.height);
-            lightMapCtx.globalCompositeOperation = 'source-over';
+        const visionMask = generateVisionMask();
+        if (visionMask) {
+            lightMapCtx.save();
+            lightMapCtx.globalCompositeOperation = 'destination-out';
+            lightMapCtx.drawImage(visionMask, 0, 0, lightMapCanvas.width, lightMapCanvas.height);
+            lightMapCtx.restore();
         }
 
         isLightMapDirty = false;
@@ -9857,190 +10040,6 @@ function displayToast(messageElement) {
             }
         }
     }
-
-    function createDarkvisionMask() {
-        const mapGridData = gridData[selectedMapFileName];
-        if (!mapGridData || !mapGridData.visible || !currentMapDisplayData.img) {
-            return null;
-        }
-
-        const darkvisionMaskCanvas = document.createElement('canvas');
-        darkvisionMaskCanvas.width = currentMapDisplayData.imgWidth;
-        darkvisionMaskCanvas.height = currentMapDisplayData.imgHeight;
-        const maskCtx = darkvisionMaskCanvas.getContext('2d');
-        maskCtx.fillStyle = 'black';
-
-        const tokensWithVision = initiativeTokens.filter(token => {
-            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
-            return character && character.vision === true;
-        });
-
-        if (tokensWithVision.length === 0) {
-            return null;
-        }
-
-        tokensWithVision.forEach(token => {
-            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
-            if (character && character.sheetData) {
-                const visionFt = parseInt(character.sheetData.vision_ft, 10) || 0;
-                const gridSqftValue = mapGridData.sqft || 5;
-                const gridPixelSize = mapGridData.scale || 50;
-
-                if (visionFt > 0 && gridSqftValue > 0) {
-                    const visionRadiusInGridSquares = visionFt / gridSqftValue;
-                    const visionRadiusInPixels = visionRadiusInGridSquares * gridPixelSize;
-
-                    maskCtx.beginPath();
-                    maskCtx.arc(token.x, token.y, visionRadiusInPixels, 0, Math.PI * 2, true);
-                    maskCtx.fill();
-                }
-            }
-        });
-
-        return darkvisionMaskCanvas;
-    }
-
-    function generateVisionMask() {
-        const mapData = detailedMapData.get(selectedMapFileName);
-        if (!mapData || !currentMapDisplayData.img) return null;
-
-        const visionMaskCanvas = document.createElement('canvas');
-        visionMaskCanvas.width = currentMapDisplayData.imgWidth;
-        visionMaskCanvas.height = currentMapDisplayData.imgHeight;
-        const visionCtx = visionMaskCanvas.getContext('2d');
-
-        const lightSources = initiativeTokens
-            .filter(token => {
-                const character = charactersData.find(c => c.id === token.characterId);
-                return character && character.vision === true;
-            })
-            .map(token => ({
-                position: { x: token.x, y: token.y }
-            }));
-
-        if (lightSources.length === 0) return null;
-
-        const walls = mapData.overlays.filter(o => o.type === 'wall');
-        const closedDoors = mapData.overlays.filter(o => o.type === 'door' && !o.isOpen);
-        const smartObjects = mapData.overlays.filter(o => o.type === 'smart_object');
-
-        const allSegments = [];
-        walls.forEach(wall => {
-            for (let i = 0; i < wall.points.length - 1; i++) {
-                allSegments.push({ p1: wall.points[i], p2: wall.points[i + 1], parent: wall });
-            }
-        });
-        closedDoors.forEach(door => {
-            allSegments.push({ p1: door.points[0], p2: door.points[1], parent: door });
-        });
-        smartObjects.forEach(object => {
-            for (let i = 0; i < object.polygon.length - 1; i++) {
-                allSegments.push({ p1: object.polygon[i], p2: object.polygon[i + 1], parent: object });
-            }
-             allSegments.push({ p1: object.polygon[object.polygon.length - 1], p2: object.polygon[0], parent: object });
-        });
-
-        const imgWidth = currentMapDisplayData.imgWidth;
-        const imgHeight = currentMapDisplayData.imgHeight;
-        allSegments.push({ p1: { x: 0, y: 0 }, p2: { x: imgWidth, y: 0 }, parent: { type: 'boundary' } });
-        allSegments.push({ p1: { x: imgWidth, y: 0 }, p2: { x: imgWidth, y: imgHeight }, parent: { type: 'boundary' } });
-        allSegments.push({ p1: { x: imgWidth, y: imgHeight }, p2: { x: 0, y: imgHeight }, parent: { type: 'boundary' } });
-        allSegments.push({ p1: { x: 0, y: imgHeight }, p2: { x: 0, y: 0 }, parent: { type: 'boundary' } });
-
-        const allVertices = [];
-        allSegments.forEach(seg => {
-            allVertices.push(seg.p1, seg.p2);
-        });
-
-        visionCtx.fillStyle = 'black';
-        visionCtx.beginPath();
-
-        lightSources.forEach(light => {
-            const visiblePoints = [];
-            const angles = new Set();
-
-            let lightIsInsideObject = false;
-            for (const so of smartObjects) {
-                if (isPointInPolygon(light.position, so.polygon)) {
-                    lightIsInsideObject = true;
-                    break;
-                }
-            }
-
-            allVertices.forEach(vertex => {
-                const angle = Math.atan2(vertex.y - light.position.y, vertex.x - light.position.x);
-                angles.add(angle - 0.0001);
-                angles.add(angle);
-                angles.add(angle + 0.0001);
-            });
-
-            const sortedAngles = Array.from(angles).sort((a, b) => a - b);
-
-            sortedAngles.forEach(angle => {
-                const ray = {
-                    x1: light.position.x,
-                    y1: light.position.y,
-                    x2: light.position.x + (imgWidth + imgHeight) * 2 * Math.cos(angle),
-                    y2: light.position.y + (imgWidth + imgHeight) * 2 * Math.sin(angle)
-                };
-
-                let closestIntersection = null;
-                let minDistance = Infinity;
-
-                allSegments.forEach(segment => {
-                    const intersectionPoint = getLineIntersection(ray, { x1: segment.p1.x, y1: segment.p1.y, x2: segment.p2.x, y2: segment.p2.y });
-                    if (intersectionPoint) {
-                        let ignoreThisIntersection = false;
-                        if (segment.parent.type === 'smart_object') {
-                            const p1 = segment.p1;
-                            const p2 = segment.p2;
-                            const normal = { x: p2.y - p1.y, y: p1.x - p2.x };
-                            const lightVector = { x: intersectionPoint.x - light.position.x, y: intersectionPoint.y - light.position.y };
-                            const dot = (lightVector.x * normal.x) + (lightVector.y * normal.y);
-                            if (!lightIsInsideObject && dot > 0) {
-                                ignoreThisIntersection = true;
-                            }
-                        }
-
-                        if (!ignoreThisIntersection) {
-                            const distance = Math.sqrt(Math.pow(intersectionPoint.x - light.position.x, 2) + Math.pow(intersectionPoint.y - light.position.y, 2));
-                            if (distance < minDistance) {
-                                minDistance = distance;
-                                closestIntersection = intersectionPoint;
-                            }
-                        }
-                    }
-                });
-
-                if (closestIntersection) {
-                    visiblePoints.push(closestIntersection);
-                } else {
-                    visiblePoints.push({ x: ray.x2, y: ray.y2 });
-                }
-            });
-
-            if (visiblePoints.length > 0) {
-                const firstPoint = visiblePoints[0];
-                visionCtx.moveTo(firstPoint.x, firstPoint.y);
-                visiblePoints.forEach(point => {
-                    visionCtx.lineTo(point.x, point.y);
-                });
-                visionCtx.closePath();
-            }
-        });
-        visionCtx.fill();
-
-        // If grid is on, clip the vision to the darkvision radius
-        const darkvisionMask = createDarkvisionMask();
-        if (darkvisionMask) {
-            visionCtx.globalCompositeOperation = 'source-in';
-            visionCtx.drawImage(darkvisionMask, 0, 0);
-            visionCtx.globalCompositeOperation = 'source-over'; // Reset for other operations
-        }
-
-        return visionMaskCanvas;
-    }
-
 
     function updateFogOfWar() {
         if (!selectedMapFileName || !currentMapDisplayData.img) return;


### PR DESCRIPTION
The real-time shadow reveal for tokens with darkvision was not being restricted by their vision radius, revealing the entire line of sight instead.

This commit updates the `recalculateLightMap` function to use the `generateVisionMask` function, which correctly combines the line-of-sight visibility polygon with the circular darkvision mask. This ensures that the real-time shadow reveal is properly constrained by the token's vision range, similar to how the fog of war is handled.

The `createDarkvisionMask` and `generateVisionMask` functions were also moved to be before `recalculateLightMap` to improve code organization.