### PR TITLE
Fix(vision): Limit real-time shadows by darkvision radius

### DIFF
--- a/Projects/DnDemicube/dm_view.html
+++ b/Projects/DnDemicube/dm_view.html
@@ -291,6 +291,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/mode/javascript/javascript.min.js"></script>
+    <script src="shared_vision.js"></script>
     <script src="dm_view.js"></script>
     <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
 

--- a/Projects/DnDemicube/dm_view.js
+++ b/Projects/DnDemicube/dm_view.js
@@ -1879,208 +1879,6 @@ function getTightBoundingBox(img) {
         });
     }
 
-    function getLineIntersection(p1, p2) {
-        const dX = p1.x2 - p1.x1;
-        const dY = p1.y2 - p1.y1;
-        const dX2 = p2.x2 - p2.x1;
-        const dY2 = p2.y2 - p2.y1;
-        const denominator = dX * dY2 - dY * dX2;
-
-        if (denominator === 0) return null;
-
-        const t = ((p2.x1 - p1.x1) * dY2 - (p2.y1 - p1.y1) * dX2) / denominator;
-        const u = -((p1.x1 - p2.x1) * dY - (p1.y1 - p2.y1) * dX) / denominator;
-
-        if (t >= 0 && u >= 0 && u <= 1) {
-            return { x: p1.x1 + t * dX, y: p1.y1 + t * dY };
-        }
-
-        return null;
-    }
-
-    function createDarkvisionMask() {
-        const mapGridData = gridData[selectedMapFileName];
-        if (!mapGridData || !mapGridData.visible || !currentMapDisplayData.img) {
-            return null;
-        }
-
-        const darkvisionMaskCanvas = document.createElement('canvas');
-        darkvisionMaskCanvas.width = currentMapDisplayData.imgWidth;
-        darkvisionMaskCanvas.height = currentMapDisplayData.imgHeight;
-        const maskCtx = darkvisionMaskCanvas.getContext('2d');
-        maskCtx.fillStyle = 'black';
-
-        const tokensWithVision = initiativeTokens.filter(token => {
-            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
-            return character && character.vision === true;
-        });
-
-        if (tokensWithVision.length === 0) {
-            return null;
-        }
-
-        tokensWithVision.forEach(token => {
-            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
-            if (character && character.sheetData) {
-                const visionFt = parseInt(character.sheetData.vision_ft, 10) || 0;
-                const gridSqftValue = mapGridData.sqft || 5;
-                const gridPixelSize = mapGridData.scale || 50;
-
-                if (visionFt > 0 && gridSqftValue > 0) {
-                    const visionRadiusInGridSquares = visionFt / gridSqftValue;
-                    const visionRadiusInPixels = visionRadiusInGridSquares * gridPixelSize;
-
-                    maskCtx.beginPath();
-                    maskCtx.arc(token.x, token.y, visionRadiusInPixels, 0, Math.PI * 2, true);
-                    maskCtx.fill();
-                }
-            }
-        });
-
-        return darkvisionMaskCanvas;
-    }
-
-    function generateVisionMask() {
-        const mapData = detailedMapData.get(selectedMapFileName);
-        if (!mapData || !currentMapDisplayData.img) return null;
-
-        const visionMaskCanvas = document.createElement('canvas');
-        visionMaskCanvas.width = currentMapDisplayData.imgWidth;
-        visionMaskCanvas.height = currentMapDisplayData.imgHeight;
-        const visionCtx = visionMaskCanvas.getContext('2d');
-
-        const lightSources = initiativeTokens
-            .filter(token => {
-                const character = charactersData.find(c => c.id === token.characterId);
-                return character && character.vision === true;
-            })
-            .map(token => ({
-                position: { x: token.x, y: token.y }
-            }));
-
-        if (lightSources.length === 0) return null;
-
-        const walls = mapData.overlays.filter(o => o.type === 'wall');
-        const closedDoors = mapData.overlays.filter(o => o.type === 'door' && !o.isOpen);
-        const smartObjects = mapData.overlays.filter(o => o.type === 'smart_object');
-
-        const allSegments = [];
-        walls.forEach(wall => {
-            for (let i = 0; i < wall.points.length - 1; i++) {
-                allSegments.push({ p1: wall.points[i], p2: wall.points[i + 1], parent: wall });
-            }
-        });
-        closedDoors.forEach(door => {
-            allSegments.push({ p1: door.points[0], p2: door.points[1], parent: door });
-        });
-        smartObjects.forEach(object => {
-            for (let i = 0; i < object.polygon.length - 1; i++) {
-                allSegments.push({ p1: object.polygon[i], p2: object.polygon[i + 1], parent: object });
-            }
-             allSegments.push({ p1: object.polygon[object.polygon.length - 1], p2: object.polygon[0], parent: object });
-        });
-
-        const imgWidth = currentMapDisplayData.imgWidth;
-        const imgHeight = currentMapDisplayData.imgHeight;
-        allSegments.push({ p1: { x: 0, y: 0 }, p2: { x: imgWidth, y: 0 }, parent: { type: 'boundary' } });
-        allSegments.push({ p1: { x: imgWidth, y: 0 }, p2: { x: imgWidth, y: imgHeight }, parent: { type: 'boundary' } });
-        allSegments.push({ p1: { x: imgWidth, y: imgHeight }, p2: { x: 0, y: imgHeight }, parent: { type: 'boundary' } });
-        allSegments.push({ p1: { x: 0, y: imgHeight }, p2: { x: 0, y: 0 }, parent: { type: 'boundary' } });
-
-        const allVertices = [];
-        allSegments.forEach(seg => {
-            allVertices.push(seg.p1, seg.p2);
-        });
-
-        visionCtx.fillStyle = 'black';
-        visionCtx.beginPath();
-
-        lightSources.forEach(light => {
-            const visiblePoints = [];
-            const angles = new Set();
-
-            let lightIsInsideObject = false;
-            for (const so of smartObjects) {
-                if (isPointInPolygon(light.position, so.polygon)) {
-                    lightIsInsideObject = true;
-                    break;
-                }
-            }
-
-            allVertices.forEach(vertex => {
-                const angle = Math.atan2(vertex.y - light.position.y, vertex.x - light.position.x);
-                angles.add(angle - 0.0001);
-                angles.add(angle);
-                angles.add(angle + 0.0001);
-            });
-
-            const sortedAngles = Array.from(angles).sort((a, b) => a - b);
-
-            sortedAngles.forEach(angle => {
-                const ray = {
-                    x1: light.position.x,
-                    y1: light.position.y,
-                    x2: light.position.x + (imgWidth + imgHeight) * 2 * Math.cos(angle),
-                    y2: light.position.y + (imgWidth + imgHeight) * 2 * Math.sin(angle)
-                };
-
-                let closestIntersection = null;
-                let minDistance = Infinity;
-
-                allSegments.forEach(segment => {
-                    const intersectionPoint = getLineIntersection(ray, { x1: segment.p1.x, y1: segment.p1.y, x2: segment.p2.x, y2: segment.p2.y });
-                    if (intersectionPoint) {
-                        let ignoreThisIntersection = false;
-                        if (segment.parent.type === 'smart_object') {
-                            const p1 = segment.p1;
-                            const p2 = segment.p2;
-                            const normal = { x: p2.y - p1.y, y: p1.x - p2.x };
-                            const lightVector = { x: intersectionPoint.x - light.position.x, y: intersectionPoint.y - light.position.y };
-                            const dot = (lightVector.x * normal.x) + (lightVector.y * normal.y);
-                            if (!lightIsInsideObject && dot > 0) {
-                                ignoreThisIntersection = true;
-                            }
-                        }
-
-                        if (!ignoreThisIntersection) {
-                            const distance = Math.sqrt(Math.pow(intersectionPoint.x - light.position.x, 2) + Math.pow(intersectionPoint.y - light.position.y, 2));
-                            if (distance < minDistance) {
-                                minDistance = distance;
-                                closestIntersection = intersectionPoint;
-                            }
-                        }
-                    }
-                });
-
-                if (closestIntersection) {
-                    visiblePoints.push(closestIntersection);
-                } else {
-                    visiblePoints.push({ x: ray.x2, y: ray.y2 });
-                }
-            });
-
-            if (visiblePoints.length > 0) {
-                const firstPoint = visiblePoints[0];
-                visionCtx.moveTo(firstPoint.x, firstPoint.y);
-                visiblePoints.forEach(point => {
-                    visionCtx.lineTo(point.x, point.y);
-                });
-                visionCtx.closePath();
-            }
-        });
-        visionCtx.fill();
-
-        // If grid is on, clip the vision to the darkvision radius
-        const darkvisionMask = createDarkvisionMask();
-        if (darkvisionMask) {
-            visionCtx.globalCompositeOperation = 'source-in';
-            visionCtx.drawImage(darkvisionMask, 0, 0);
-            visionCtx.globalCompositeOperation = 'source-over'; // Reset for other operations
-        }
-
-        return visionMaskCanvas;
-    }
-
     let shadowAnimationId = null;
 
     function recalculateLightMap() {
@@ -2231,7 +2029,7 @@ function getTightBoundingBox(img) {
             lightMapCtx.restore();
         });
 
-        const visionMask = generateVisionMask();
+        const visionMask = generateVisionMask(currentMapDisplayData.imgWidth, currentMapDisplayData.imgHeight, mapData.overlays, gridData[selectedMapFileName], initiativeTokens, activeInitiative);
         if (visionMask) {
             lightMapCtx.save();
             lightMapCtx.globalCompositeOperation = 'destination-out';
@@ -10051,7 +9849,7 @@ function displayToast(messageElement) {
             return;
         }
 
-        const visionMaskCanvas = generateVisionMask();
+        const visionMaskCanvas = generateVisionMask(currentMapDisplayData.imgWidth, currentMapDisplayData.imgHeight, mapData.overlays, gridData[selectedMapFileName], initiativeTokens, activeInitiative);
 
         if (visionMaskCanvas) {
             const fowCtx = fowCanvas.getContext('2d');

--- a/Projects/DnDemicube/player_view.html
+++ b/Projects/DnDemicube/player_view.html
@@ -307,6 +307,7 @@
             <div id="character-preview-body"></div>
         </div>
     </div>
+    <script src="shared_vision.js"></script>
     <script src="player_view.js"></script>
     <div id="dice-roller-overlay" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-20" style="display: none;">
         <!-- ... dice roller content ... -->

--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -342,11 +342,10 @@ function recalculateLightMap_Player() {
     const lightSources = [...dmLightSources, ...tokenLightSources];
     const walls = currentOverlays.filter(o => o.type === 'wall');
     const closedDoors = currentOverlays.filter(o => o.type === 'door' && !o.isOpen);
-    // Smart objects are only visible to the DM, so we don't filter them here for the player.
     const smartObjects = currentOverlays.filter(o => o.type === 'smart_object');
 
     lightMapCtx.clearRect(0, 0, lightMapCanvas.width, lightMapCanvas.height);
-    lightMapCtx.fillStyle = 'rgba(0, 0, 0, 1)'; // Full black for player fog of war
+    lightMapCtx.fillStyle = 'rgba(0, 0, 0, 1)';
     lightMapCtx.fillRect(0, 0, lightMapCanvas.width, lightMapCanvas.height);
 
     const lightScale = renderQuality;
@@ -417,7 +416,7 @@ function recalculateLightMap_Player() {
                     if (segment.parent.type === 'smart_object') {
                         const p1 = segment.p1;
                         const p2 = segment.p2;
-                        const normal = { x: p2.y - p1.y, y: p1.x - p2.x }; // Outward-facing normal for clockwise polygons
+                        const normal = { x: p2.y - p1.y, y: p1.x - p2.x };
                         const lightVector = { x: intersectionPoint.x - light.position.x, y: intersectionPoint.y - light.position.y };
                         const dot = (lightVector.x * normal.x) + (lightVector.y * normal.y);
 
@@ -457,6 +456,14 @@ function recalculateLightMap_Player() {
         }
         lightMapCtx.restore();
     });
+
+    const visionMask = generateVisionMask(currentMapDisplayData.imgWidth, currentMapDisplayData.imgHeight, currentOverlays, currentGridData, initiativeTokens, activeInitiative);
+    if (visionMask) {
+        lightMapCtx.save();
+        lightMapCtx.globalCompositeOperation = 'destination-out';
+        lightMapCtx.drawImage(visionMask, 0, 0, lightMapCanvas.width, lightMapCanvas.height);
+        lightMapCtx.restore();
+    }
 
     isLightMapDirty = false;
 }

--- a/Projects/DnDemicube/shared_vision.js
+++ b/Projects/DnDemicube/shared_vision.js
@@ -1,0 +1,196 @@
+function getLineIntersection(p1, p2) {
+    const dX = p1.x2 - p1.x1;
+    const dY = p1.y2 - p1.y1;
+    const dX2 = p2.x2 - p2.x1;
+    const dY2 = p2.y2 - p2.y1;
+    const denominator = dX * dY2 - dY * dX2;
+
+    if (denominator === 0) return null;
+
+    const t = ((p2.x1 - p1.x1) * dY2 - (p2.y1 - p1.y1) * dX2) / denominator;
+    const u = -((p1.x1 - p2.x1) * dY - (p1.y1 - p2.y1) * dX) / denominator;
+
+    if (t >= 0 && u >= 0 && u <= 1) {
+        return { x: p1.x1 + t * dX, y: p1.y1 + t * dY };
+    }
+
+    return null;
+}
+
+function createDarkvisionMask(imgWidth, imgHeight, gridData, initiativeTokens, activeInitiative) {
+    if (!gridData || !gridData.visible || !imgWidth || !imgHeight) {
+        return null;
+    }
+
+    const darkvisionMaskCanvas = document.createElement('canvas');
+    darkvisionMaskCanvas.width = imgWidth;
+    darkvisionMaskCanvas.height = imgHeight;
+    const maskCtx = darkvisionMaskCanvas.getContext('2d');
+    maskCtx.fillStyle = 'black';
+
+    const tokensWithVision = initiativeTokens.filter(token => {
+        const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
+        return character && character.vision === true;
+    });
+
+    if (tokensWithVision.length === 0) {
+        return null;
+    }
+
+    tokensWithVision.forEach(token => {
+        const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
+        if (character && character.sheetData) {
+            const visionFt = parseInt(character.sheetData.vision_ft, 10) || 0;
+            const gridSqftValue = gridData.sqft || 5;
+            const gridPixelSize = gridData.scale || 50;
+
+            if (visionFt > 0 && gridSqftValue > 0) {
+                const visionRadiusInGridSquares = visionFt / gridSqftValue;
+                const visionRadiusInPixels = visionRadiusInGridSquares * gridPixelSize;
+
+                maskCtx.beginPath();
+                maskCtx.arc(token.x, token.y, visionRadiusInPixels, 0, Math.PI * 2, true);
+                maskCtx.fill();
+            }
+        }
+    });
+
+    return darkvisionMaskCanvas;
+}
+
+function generateVisionMask(imgWidth, imgHeight, overlays, gridData, initiativeTokens, activeInitiative) {
+    if (!imgWidth || !imgHeight) return null;
+
+    const visionMaskCanvas = document.createElement('canvas');
+    visionMaskCanvas.width = imgWidth;
+    visionMaskCanvas.height = imgHeight;
+    const visionCtx = visionMaskCanvas.getContext('2d');
+
+    const lightSources = initiativeTokens
+        .filter(token => {
+            const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
+            return character && character.vision === true;
+        })
+        .map(token => ({
+            position: { x: token.x, y: token.y }
+        }));
+
+    if (lightSources.length === 0) return null;
+
+    const walls = overlays.filter(o => o.type === 'wall');
+    const closedDoors = overlays.filter(o => o.type === 'door' && !o.isOpen);
+    const smartObjects = overlays.filter(o => o.type === 'smart_object');
+
+    const allSegments = [];
+    walls.forEach(wall => {
+        for (let i = 0; i < wall.points.length - 1; i++) {
+            allSegments.push({ p1: wall.points[i], p2: wall.points[i + 1], parent: wall });
+        }
+    });
+    closedDoors.forEach(door => {
+        allSegments.push({ p1: door.points[0], p2: door.points[1], parent: door });
+    });
+    smartObjects.forEach(object => {
+        for (let i = 0; i < object.polygon.length - 1; i++) {
+            allSegments.push({ p1: object.polygon[i], p2: object.polygon[i + 1], parent: object });
+        }
+         allSegments.push({ p1: object.polygon[object.polygon.length - 1], p2: object.polygon[0], parent: object });
+    });
+
+    allSegments.push({ p1: { x: 0, y: 0 }, p2: { x: imgWidth, y: 0 }, parent: { type: 'boundary' } });
+    allSegments.push({ p1: { x: imgWidth, y: 0 }, p2: { x: imgWidth, y: imgHeight }, parent: { type: 'boundary' } });
+    allSegments.push({ p1: { x: imgWidth, y: imgHeight }, p2: { x: 0, y: imgHeight }, parent: { type: 'boundary' } });
+    allSegments.push({ p1: { x: 0, y: imgHeight }, p2: { x: 0, y: 0 }, parent: { type: 'boundary' } });
+
+    const allVertices = [];
+    allSegments.forEach(seg => {
+        allVertices.push(seg.p1, seg.p2);
+    });
+
+    visionCtx.fillStyle = 'black';
+    visionCtx.beginPath();
+
+    lightSources.forEach(light => {
+        const visiblePoints = [];
+        const angles = new Set();
+
+        let lightIsInsideObject = false;
+        for (const so of smartObjects) {
+            if (isPointInPolygon(light.position, so.polygon)) {
+                lightIsInsideObject = true;
+                break;
+            }
+        }
+
+        allVertices.forEach(vertex => {
+            const angle = Math.atan2(vertex.y - light.position.y, vertex.x - light.position.x);
+            angles.add(angle - 0.0001);
+            angles.add(angle);
+            angles.add(angle + 0.0001);
+        });
+
+        const sortedAngles = Array.from(angles).sort((a, b) => a - b);
+
+        sortedAngles.forEach(angle => {
+            const ray = {
+                x1: light.position.x,
+                y1: light.position.y,
+                x2: light.position.x + (imgWidth + imgHeight) * 2 * Math.cos(angle),
+                y2: light.position.y + (imgWidth + imgHeight) * 2 * Math.sin(angle)
+            };
+
+            let closestIntersection = null;
+            let minDistance = Infinity;
+
+            allSegments.forEach(segment => {
+                const intersectionPoint = getLineIntersection(ray, { x1: segment.p1.x, y1: segment.p1.y, x2: segment.p2.x, y2: segment.p2.y });
+                if (intersectionPoint) {
+                    let ignoreThisIntersection = false;
+                    if (segment.parent.type === 'smart_object') {
+                        const p1 = segment.p1;
+                        const p2 = segment.p2;
+                        const normal = { x: p2.y - p1.y, y: p1.x - p2.x };
+                        const lightVector = { x: intersectionPoint.x - light.position.x, y: intersectionPoint.y - light.position.y };
+                        const dot = (lightVector.x * normal.x) + (lightVector.y * normal.y);
+                        if (!lightIsInsideObject && dot > 0) {
+                            ignoreThisIntersection = true;
+                        }
+                    }
+
+                    if (!ignoreThisIntersection) {
+                        const distance = Math.sqrt(Math.pow(intersectionPoint.x - light.position.x, 2) + Math.pow(intersectionPoint.y - light.position.y, 2));
+                        if (distance < minDistance) {
+                            minDistance = distance;
+                            closestIntersection = intersectionPoint;
+                        }
+                    }
+                }
+            });
+
+            if (closestIntersection) {
+                visiblePoints.push(closestIntersection);
+            } else {
+                visiblePoints.push({ x: ray.x2, y: ray.y2 });
+            }
+        });
+
+        if (visiblePoints.length > 0) {
+            const firstPoint = visiblePoints[0];
+            visionCtx.moveTo(firstPoint.x, firstPoint.y);
+            visiblePoints.forEach(point => {
+                visionCtx.lineTo(point.x, point.y);
+            });
+            visionCtx.closePath();
+        }
+    });
+    visionCtx.fill();
+
+    const darkvisionMask = createDarkvisionMask(imgWidth, imgHeight, gridData, initiativeTokens, activeInitiative);
+    if (darkvisionMask) {
+        visionCtx.globalCompositeOperation = 'source-in';
+        visionCtx.drawImage(darkvisionMask, 0, 0);
+        visionCtx.globalCompositeOperation = 'source-over';
+    }
+
+    return visionMaskCanvas;
+}


### PR DESCRIPTION
The real-time shadow reveal for tokens was not being correctly restricted by their darkvision radius. Instead, it revealed the entire line of sight. This was happening in both the DM and Player views.

This commit refactors the vision calculation logic into a new shared file, `shared_vision.js`, to avoid code duplication. The core of the fix is in the `generateVisionMask` function, which now correctly combines the line-of-sight polygon with the circular darkvision mask using `globalCompositeOperation = 'source-in'`. This ensures that only the area visible by line-of-sight *and* within the darkvision circle is revealed.

Both `dm_view.js` and `player_view.js` have been updated to use this new shared logic, and their respective HTML files have been updated to include the new script.