### PR TITLE
Fix player vision and light source intersection

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -321,16 +321,17 @@ function createDarkvisionMask_Player() {
     const maskCtx = darkvisionMaskCanvas.getContext('2d');
     maskCtx.fillStyle = 'black';
 
-    const tokensWithVision = initiativeTokens.filter(token => {
+    const tokensWithDarkvision = initiativeTokens.filter(token => {
         const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
-        return character && character.vision === true;
+        const visionFt = parseInt(character?.sheetData?.vision_ft, 10) || 0;
+        return character && character.vision === true && visionFt > 0;
     });
 
-    if (tokensWithVision.length === 0) {
+    if (tokensWithDarkvision.length === 0) {
         return null;
     }
 
-    tokensWithVision.forEach(token => {
+    tokensWithDarkvision.forEach(token => {
         const character = activeInitiative.find(c => c.uniqueId === token.uniqueId);
         if (character && character.sheetData) {
             const visionFt = parseInt(character.sheetData.vision_ft, 10) || 0;
@@ -522,23 +523,30 @@ function generateVisionMask_Player() {
     });
     tokenVisionCtx.fill();
 
-    const darkvisionMask = createDarkvisionMask_Player();
-    if (darkvisionMask) {
-        tokenVisionCtx.globalCompositeOperation = 'source-in';
-        tokenVisionCtx.drawImage(darkvisionMask, 0, 0);
-        tokenVisionCtx.globalCompositeOperation = 'source-over';
+    const lightSourceCanvas = document.createElement('canvas');
+    lightSourceCanvas.width = visionMaskCanvas.width;
+    lightSourceCanvas.height = visionMaskCanvas.height;
+    const lightSourceCtx = lightSourceCanvas.getContext('2d');
+    if (visibleDmLightSources.length > 0) {
+        lightSourceCtx.fillStyle = 'black';
+        lightSourceCtx.beginPath();
+        visibleDmLightSources.forEach(light => {
+            calculateAndDrawVisionForSource(light, lightSourceCtx);
+        });
+        lightSourceCtx.fill();
     }
 
     visionCtx.drawImage(tokenVisionCanvas, 0, 0);
+    visionCtx.globalCompositeOperation = 'source-in';
+    visionCtx.drawImage(lightSourceCanvas, 0, 0);
 
-    if (visibleDmLightSources.length > 0) {
-        visionCtx.fillStyle = 'black';
-        visionCtx.beginPath();
-        visibleDmLightSources.forEach(light => {
-            calculateAndDrawVisionForSource(light, visionCtx);
-        });
-        visionCtx.fill();
+    const darkvisionMask = createDarkvisionMask_Player();
+    if (darkvisionMask) {
+        visionCtx.globalCompositeOperation = 'lighter';
+        visionCtx.drawImage(darkvisionMask, 0, 0);
     }
+
+    visionCtx.globalCompositeOperation = 'source-over';
 
     return visionMaskCanvas;
 }


### PR DESCRIPTION
Refactors the player view rendering logic to correctly display the intersection of a token's line of sight and a light source's illumination.

Previously, the player view would show the union of vision and light, leading to incorrect map reveals.

The new implementation separates the generation of vision masks and light source masks, and then computes their intersection.

This ensures that the map is only revealed where a token can see and there is light, while preserving darkvision functionality in unlit areas.