### PR TITLE
fix(vision): Correct player view fog of war and initial load rendering

### DIFF
--- a/Projects/DnDemicube/player_view.js
+++ b/Projects/DnDemicube/player_view.js
@@ -810,6 +810,20 @@ window.addEventListener('message', (event) => {
                         drawMapAndOverlays(); // This draws the main map
 
                         isLightMapDirty = true;
+                        recalculateLightMap_Player(); // Force immediate calculation
+
+                        const shadowCtx = shadowCanvas.getContext('2d');
+                        shadowCtx.clearRect(0, 0, shadowCanvas.width, shadowCanvas.height);
+                        if (lightMapCanvas) {
+                            const { scale, originX, originY } = currentMapTransform;
+                            shadowCtx.save();
+                            shadowCtx.translate(originX, originY);
+                            shadowCtx.scale(scale, scale);
+                            shadowCtx.imageSmoothingEnabled = false;
+                            shadowCtx.drawImage(lightMapCanvas, 0, 0, currentMapDisplayData.imgWidth, currentMapDisplayData.imgHeight);
+                            shadowCtx.restore();
+                        }
+
                         toggleShadowAnimation(data.active);
                     };
                     img.onerror = () => {


### PR DESCRIPTION
This commit resolves two rendering issues in the player view.

First, it fixes a visual bug where the player's map view would incorrectly show the fog of war in an area that should be revealed by a light source. The original vision calculation logic incorrectly clipped a token's line of sight to its darkvision radius. The logic has been refactored to correctly calculate the union of vision from darkvision and from lit areas that are within a token's line of sight.

Second, it fixes a race condition on initial map load where the map would be visible for a frame before the shadow layer was rendered. A synchronous, one-time draw of the shadow layer has been added to the map loading logic to ensure the shadows are present in the first frame.